### PR TITLE
Adds integrations for CI/CD runs

### DIFF
--- a/qodana.sarif.json
+++ b/qodana.sarif.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": []
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,8 @@
+version: "1.0"
+profile:
+    name: qodana.recommended
+bootstrap: pip install -r requirements.txt
+raiseLicenseProblems: true
+dependencyIgnores:
+    # certifi is "copy-left" under MPL-2.0 - we don't modify it, so we are safe (e.g., package "requests" is the same)
+    -   name: "certifi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit-edge[video]>=1.13.0,<2.0
+inorbit-edge[video]>=1.14.0,<2.0
 pydantic>=2.6,<3.0
 pytz>=2024.1
 PyYAML>=6.0,<7.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ GITHUB_ORG_URL = "https://github.com/inorbit-ai"
 GITHUB_REPO_URL = f"{GITHUB_ORG_URL}/inorbit-connector-python"
 TEAMCITY_PROJECT_URL = (
     "https://inorbit.teamcity.com/project/"
-    "Engineering_Development_DeveloperPortal_Connectors_InorbitConnectorPython"
+    "Engineering_Development_DeveloperPortal_InorbitConnectorPython"
 )
 
 with open("README.md") as file:
@@ -38,6 +38,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     description="A Python library for connectors in the InOrbit RobOps ecosystem.",
+    download_url=f"{GITHUB_REPO_URL}/archive/refs/tags/{VERSION}.zip",
     install_requires=install_requirements,
     keywords=["inorbit", "robops", "robotics"],
     license="MIT",


### PR DESCRIPTION
Adds linting/tests/qodana to the CI/CD pipeline in TeamCity. Screenshots below...

**README w/ Build Badges**
![Screenshot 2024-05-27 150018](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/09cebd62-2000-4a5b-a303-7a754b0bb0dd)

**Build Matrix**
![Screenshot 2024-05-27 150035](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/32033940-1416-479d-86cb-68b03c3de22d)

**Unit Tests**
![Screenshot 2024-05-27 150053](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/08ece105-b1ad-41f0-8d51-da52a89322af)

**Code Coverage**
![Screenshot 2024-05-27 150103](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/81f02453-6aa0-42c9-9816-9574c079c19c)

**Linting**
![Screenshot 2024-05-27 150115](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/0e07b84e-3633-42fc-a498-5a3cb9458960)

**Qodana**
![Screenshot 2024-05-27 150209](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/0d66fd20-1bff-44e2-abbd-107758c55bbe)

**GitHub Status Reports**
![Screenshot 2024-05-27 150329](https://github.com/inorbit-ai/inorbit-connector-python/assets/156375733/ab4114e2-efa9-4a63-be14-fcbea344edee)
