### PR TITLE
Pass `account_id` to RobotSession

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -51,10 +51,11 @@ class Connector:
         robot_session_config = RobotSessionModel(
             api_key=config.api_key,
             endpoint=config.api_url,
+            account_id=config.account_id,
             robot_id=robot_id,
             robot_name=robot_id,
         )
-        self._robot_session = RobotSession(**robot_session_config.dict())
+        self._robot_session = RobotSession(**robot_session_config.model_dump())
 
     def _connect(self) -> None:
         """Connect to any external services.

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -54,9 +54,10 @@ class InorbitConnectorConfig(BaseModel):
     location_tz: str = DEFAULT_TIMEZONE
     log_level: LogLevels = LogLevels.INFO
     user_scripts_dir: Path | None = None
+    account_id: str | None = None
 
     # noinspection PyMethodParameters
-    @field_validator("api_key")
+    @field_validator("api_key", "account_id")
     def check_whitespace(cls, value: str) -> str:
         """Check if the api_key contains whitespace.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit-edge[video]>=1.14.0,<2.0
+inorbit-edge[video]>=1.15.0,<2.0
 pydantic>=2.6,<3.0
 pytz>=2024.1
 PyYAML>=6.0,<7.0

--- a/scripts/example.yaml
+++ b/scripts/example.yaml
@@ -7,6 +7,8 @@ my-example-robot:
   connector_type: example_bot
   # Update rate of the connector's main execution loop in Hz
   connector_update_freq: 5.0
+  # The ID of the InOrbit account that owns the robots
+  account_id: my_inorbit_account
 
   # This is where you define custom fields specific to your robot's connector
   connector_config:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,6 +72,12 @@ class TestInorbitConnectorConfig:
         with pytest.raises(ValidationError, match="Whitespaces are not allowed"):
             InorbitConnectorConfig(**init_input)
 
+    def test_invalid_account_id(self, base_model):
+        init_input = base_model.copy()
+        init_input["account_id"] = "account id with spaces"
+        with pytest.raises(ValidationError, match="Whitespaces are not allowed"):
+            InorbitConnectorConfig(**init_input)
+
     def test_invalid_connector_config(self, base_model):
         init_input = {
             "connector_type": "valid_connector",


### PR DESCRIPTION
## Description

Passes `account_id` to `RobotSession` (requires `inorbit-edge>=1.15.0`)
Also replaced usage of deprecated method `dict()` of Pydantic models with `model_dump()`.