### PR TITLE
Register custom scripts directory and command callbacks automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,5 +152,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# Covers JetBrains IDEs
-.idea/**
+# Covers various IDEs
+.idea/
+.vscode/

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -81,6 +81,9 @@ class Connector:
             user_scripts_path = os.path.expanduser(path)
             create_dir = kwargs.get("create_user_scripts_dir", False)
             self._register_user_scripts(user_scripts_path, create_dir)
+        # If enabled, register the provided custom commands handler
+        if kwargs.get("register_custom_command_handler", True):
+            self._register_custom_command_handler(self._inorbit_command_handler)
 
     def _register_user_scripts(self, dir: str, create: bool) -> None:
         """Register user scripts folder.
@@ -103,6 +106,31 @@ class Connector:
             # More script types can be supported, but right now is only limited to
             # bash scripts
             self._robot_session.register_commands_path(dir, exec_name_regex=r".*\.sh")
+
+    def _register_custom_command_handler(self, handler: callable) -> None:
+        """Register a custom command handler.
+
+        Args:
+            handler (Callable): The custom command handler.
+        """
+        self._robot_session.register_custom_command_handler(handler)
+
+    def _inorbit_command_handler(self, command_name: str, args: list, options: dict):
+        """Callback method for command messages. This method is called when a command
+        is received from InOrbit.
+        Will automatically be registered if `register_custom_command_handler`
+        constructor keyword argument is set.
+
+        Args:
+            command_name (str): The name of the command
+            args (list): The list of arguments
+            options (dict): The dictionary of options.
+                It usually contains `result_function()` which must be called with "0"
+                to indicate success or any other value to indicate failure. See
+                https://github.com/inorbit-ai/edge-sdk-python for usage information.
+        """
+        # Overwrite this in subclass to handle custom commands
+        self._logger.warning(f"Custom command {command_name} not implemented.")
 
     def _connect(self) -> None:
         """Connect to any external services.

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -4,6 +4,7 @@
 # Copyright 2024 InOrbit, Inc.
 
 # Standard
+import os
 import logging
 import threading
 from time import sleep
@@ -25,7 +26,7 @@ class Connector:
     disconnect() methods (with calls to the superclass).
     """
 
-    def __init__(self, robot_id: str, config: InorbitConnectorConfig) -> None:
+    def __init__(self, robot_id: str, config: InorbitConnectorConfig, **kwargs) -> None:
         """Initialize a new InOrbit connector.
 
         This class handles bidirectional communication with InOrbit.
@@ -33,6 +34,16 @@ class Connector:
         Args:
             robot_id (str): The ID of the InOrbit robot
             config (InorbitConnectorConfig): The connector configuration
+
+        Keyword Args:
+            register_user_scripts (bool): Register user scripts automatically.
+                Default is False
+            default_user_scripts_dir (str): The default user scripts directory path to
+                use if not explicitly set in the config.
+                Default is "~/.inorbit_connectors/connector-{robot_id}/local/"
+            create_user_scripts_dir (bool): The path to the user scripts directory.
+                Relevant only if register_user_scripts is True.
+                Default is False
         """
 
         # Common information
@@ -57,6 +68,41 @@ class Connector:
             robot_name=robot_id,
         )
         self._robot_session = RobotSession(**robot_session_config.model_dump())
+
+        # If enabled, register user scripts
+        if kwargs.get("register_user_scripts", False):
+            # Get user_scripts path
+            path = config.user_scripts_dir
+            if path is None:
+                path = kwargs.get(
+                    "default_user_scripts_dir",
+                    f"~/.inorbit_connectors/connector-{robot_id}/local/",
+                )
+            user_scripts_path = os.path.expanduser(path)
+            create_dir = kwargs.get("create_user_scripts_dir", False)
+            self._register_user_scripts(user_scripts_path, create_dir)
+
+    def _register_user_scripts(self, dir: str, create: bool) -> None:
+        """Register user scripts folder.
+
+        Args:
+            dir (str): The path to the user scripts directory.
+            create (bool): Create the directory if it doesn't exist.
+        """
+        if not os.path.exists(dir):
+            if create:
+                self._logger.info(f"Creating user_scripts directory: {dir}")
+                os.makedirs(dir, exist_ok=True)
+            else:
+                self._logger.warning(f"User_scripts directory not found: {dir}")
+                return
+        if os.path.exists(dir):
+            self._logger.info(f"Registering user_scripts path: {dir}")
+            # NOTE: this only supports bash execution (exec_name_regex is set to
+            # files with '.sh' extension).
+            # More script types can be supported, but right now is only limited to
+            # bash scripts
+            self._robot_session.register_commands_path(dir, exec_name_regex=r".*\.sh")
 
     def _connect(self) -> None:
         """Connect to any external services.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit-edge[video]>=1.15.1,<2.0
+inorbit-edge[video]>=1.17.0,<2.0
 pydantic>=2.6,<3.0
 pytz>=2024.1
 PyYAML>=6.0,<7.0

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -240,16 +240,16 @@ class TestConnector:
             connector.publish_pose(0, 0, 0, "frameB")
             assert mock_publish_map.call_count == 2  # Called again
 
-    def test_registers_user_scripts(self, base_model, tmp_path):
+    def test_register_user_scripts(self, base_model, tmp_path):
         with patch(
             f"{RobotSession.__module__}.{RobotSession.__name__}"
             ".register_commands_path",
             autospec=True,
-        ) as mock_path_session:
+        ) as mock_register_path:
             # Test it doesn't register callbacks if no user scripts are specified
             Connector("TestRobot", InorbitConnectorConfig(**base_model))
-            mock_path_session.assert_not_called()
-            mock_path_session.reset_mock()
+            mock_register_path.assert_not_called()
+            mock_register_path.reset_mock()
 
             # Test it attepts to registers callbacks if user scripts are specified, but
             # fails if the directory does not exist
@@ -259,8 +259,8 @@ class TestConnector:
                 register_user_scripts=True,
                 default_user_scripts_dir=tmp_path / "./not_a_dir",
             )
-            mock_path_session.assert_not_called()
-            mock_path_session.reset_mock()
+            mock_register_path.assert_not_called()
+            mock_register_path.reset_mock()
 
             # Test it attepts to registers callbacks if user scripts are specified and
             # the directory exists
@@ -270,8 +270,8 @@ class TestConnector:
                 register_user_scripts=True,
                 default_user_scripts_dir=tmp_path,
             )
-            mock_path_session.assert_called_once()
-            mock_path_session.reset_mock()
+            mock_register_path.assert_called_once()
+            mock_register_path.reset_mock()
 
             # Test it creates the scripts folder if specified
             Connector(
@@ -281,5 +281,24 @@ class TestConnector:
                 default_user_scripts_dir=tmp_path / "a_dir",
                 create_user_scripts_dir=True,
             )
-            mock_path_session.assert_called_once()
-            mock_path_session.reset_mock()
+            mock_register_path.assert_called_once()
+            mock_register_path.reset_mock()
+
+    def test_register_command_callback(self, base_model):
+        with patch(
+            f"{Connector.__module__}.{Connector.__name__}"
+            "._register_custom_command_handler",
+            autospec=True,
+        ) as mock_register_callback:
+            # Test it registers by default
+            Connector("TestRobot", InorbitConnectorConfig(**base_model))
+            mock_register_callback.assert_called_once()
+            mock_register_callback.reset_mock()
+
+            # Test it doesn't register if explicitly disabled
+            Connector(
+                "TestRobot",
+                InorbitConnectorConfig(**base_model),
+                register_custom_command_handler=False,
+            )
+            mock_register_callback.assert_not_called()


### PR DESCRIPTION
The following new constructor keyword arguments allows configuring the behavior of the connector when instantiated:            * `register_user_scripts (bool)`: Register user scripts automatically.
                Default is False
* `default_user_scripts_dir (str)`: The default user scripts directory path to use if not explicitly set in the config.
                Default is "~/.inorbit_connectors/connector-{robot_id}/local/"
* `create_user_scripts_dir (bool)`: The path to the user scripts directory. Relevant only if register_user_scripts is True.
                Default is False