### PR TITLE
`.join()` method

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -246,6 +246,14 @@ class Connector:
             self.__thread = threading.Thread(target=self.__run)
             self.__thread.start()
 
+    def join(self) -> None:
+        """Join the execution loop of this connector.
+
+        This method should be called to join the execution loop of this connector and
+        will block until it ends.
+        """
+        self.__thread.join()
+
     def stop(self) -> None:
         """Stop the execution loop of this connector.
 

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -7,7 +7,6 @@
 import logging
 import os
 import random
-from time import sleep
 
 # Third-party
 from pydantic import field_validator, BaseModel
@@ -160,9 +159,7 @@ def main():
     connector.start()
 
     try:
-        while True:
-            # Yield execution to another thread
-            sleep(0)
+        connector.join()
     except KeyboardInterrupt:
         logger.info("...exiting")
         connector.stop()

--- a/scripts/example.yaml
+++ b/scripts/example.yaml
@@ -11,7 +11,7 @@ my-example-robot:
   account_id: my_inorbit_account
   # Robot key for InOrbit Connect robots (optional, delete if unused)
   # See https://api.inorbit.ai/docs/index.html#operation/generateRobotKey
-  inorbit_robot_key: my_inorbit_robot_key
+  inorbit_robot_key:
   # Map configuration (optional)
   maps:
     frameIdA:


### PR DESCRIPTION
## Description

Adds a `.join()` method for blocking while the execution thread runs.

Note: The robot key was removed from the example config, since having a "wrong" value would make the connection fail. With a blank value the setting is not used.