### PR TITLE
Fixes to the usage example

### DIFF
--- a/scripts/example.py
+++ b/scripts/example.py
@@ -129,6 +129,15 @@ class ExampleBotConnector(Connector):
         hdd = random.uniform(0.3, 0.7)
         self._robot_session.publish_system_stats(cpu, ram, hdd)
 
+        # Publish pose...
+        x = random.uniform(-1.0, 1.0)
+        y = random.uniform(-1.0, 1.0)
+        yaw = random.uniform(-3.14, 3.14)
+        # Note that if the frame_id is present in the maps definition,
+        # the map image will be automatically uploaded to InOrbit.
+        frame_id = "frameIdA"
+        self.publish_pose(x, y, yaw, frame_id)
+
 
 def main():
     # Setup the logger

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -104,7 +104,7 @@ class ExampleBotConnector(Connector):
 
         This method should always call super.
         """
-        super()._connect()
+        super()._disconnect()
         # Do some magic here...
         self._logger.info(f"Disconnected to robot services at API {self.api_version}")
 


### PR DESCRIPTION
## Description

* Fix the disconnect method, which was actually reconnecting again
* Publish random poses and an example map

## Demo

![image](https://github.com/user-attachments/assets/4d6c7c29-c855-4cf1-8de6-8fcd9c681337)

Logs:

```
INFO:RobotSession:Waiting for MQTT connection state '_is_connected' ...
INFO:RobotSession:Connected to MQTT
INFO:RobotSession:Publishing status 1. ret = (0, 1).
INFO:RobotSession:Robot status '1' published: 1.
INFO:RobotSession:MQTT connection initiated. localdev.com:1883 (MQTT)
INFO:inorbit_connector.connector:Connected to robot services at API v1
INFO:inorbit_connector.connector:Updating map frameIdA with new pose.
INFO:RobotSession:Received map request for label 'mapA' with hash 4565286020005755223
^CINFO:main:...exiting
INFO:RobotSession:Ending robot session
INFO:RobotSession:Publishing status 0. ret = (0, 2865).
INFO:RobotSession:Robot status '0' published: 1.
INFO:RobotSession:Waiting for MQTT connection state '_is_disconnected' ...
INFO:RobotSession:Disconnected from MQTT broker
INFO:inorbit_connector.connector:Disconnected to robot services at API v1
```
