### PR TITLE
Disable publishing to Test PyPI

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+  # Only for testing
+  pull_request:
+    branches:
+      - main
+
 jobs:
   # Always run build
   build:
@@ -53,6 +58,7 @@ jobs:
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
           repository-url: https://test.pypi.org/legacy/
 
   # Only publish to PyPI on version bumps

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
 
-  # Only for testing
-  pull_request:
-    branches:
-      - main
-
 jobs:
   # Always run build
   build:
@@ -58,7 +53,6 @@ jobs:
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          verbose: true
           repository-url: https://test.pypi.org/legacy/
 
   # Only publish to PyPI on version bumps

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -33,27 +33,30 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  # NOTE(b-Tomas): This job has been disabled. It would fail with "File already exists" since
+  # version numbers don't change between pushes.
+  # See https://test.pypi.org/help/#file-name-reuse
   # Always publish to TestPyPI after building
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/inorbit-connector
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+  # publish-to-testpypi:
+  #   name: Publish Python 🐍 distribution 📦 to TestPyPI
+  #   needs:
+  #     - build
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: testpypi
+  #     url: https://test.pypi.org/p/inorbit-connector
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - name: Download all the dists
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: python-package-distributions
+  #         path: dist/
+  #     - name: Publish distribution 📦 to TestPyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
 
   # Only publish to PyPI on version bumps
   publish-to-pypi:


### PR DESCRIPTION
## Description

Disable publishing to Test PyPI. It would return "Filename already exists" on every merge, since versions cannot be overriden (not even on Test PyPI). See https://test.pypi.org/help/#file-name-reuse
