### PR TITLE
Fix call to non-existing method from Thread on  `.stop()`

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -328,8 +328,7 @@ class Connector(ABC):
         self.__stop_event.set()
         self.__thread.join(timeout=5)
         if self.__thread.is_alive():
-            self._logger.error("Thread did not stop in time, forcefully killing")
-            self.__thread.kill()
+            raise Exception("Thread did not stop in time")
 
     def __run_connector(self):
         """The target function of the connector's thread.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -284,10 +284,21 @@ class TestConnector:
 
     def test_stop(self, base_connector):
         base_connector._Connector__thread = MagicMock()
+        base_connector._Connector__thread.is_alive.return_value = False
         assert not base_connector._Connector__stop_event.is_set()
         base_connector.stop()
         assert base_connector._Connector__stop_event.is_set()
         assert base_connector._Connector__thread.join.called
+
+    def test_stop_raises_exception_if_thread_does_not_stop_in_time(
+        self, base_connector
+    ):
+        base_connector._Connector__thread = MagicMock()
+        assert not base_connector._Connector__stop_event.is_set()
+        with pytest.raises(Exception, match="Thread did not stop in time"):
+            base_connector.stop()
+            assert base_connector._Connector__stop_event.is_set()
+            assert base_connector._Connector__thread.join.called
 
     def test_run_loop(self, base_model):
         connector = Connector("TestRobot", InorbitConnectorConfig(**base_model))


### PR DESCRIPTION
## Description

There is no built-in way to forcefully kill a Thread and it is generally considered a bad practice.

Raising an exception guarantees the connector is stopped at least in a not clean way (which was already happening, but through calling a non existing method).

## Demo

`Ctrl+C` while a connector performs a slow, blocking task:

![image](https://github.com/user-attachments/assets/7aa0ec1e-0c00-4b24-b005-6219e329db72)

