### PR TITLE
Bump inorbit_edge version to 1.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit-edge[video]>=1.17.0,<2.0
+inorbit_edge[video]>=1.20.1,<2.0
 pydantic>=2.6,<3.0
 pytz>=2024.1
 PyYAML>=6.0,<7.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    flake8
-    black --check --diff .
+    flake8 inorbit_connector
+    black --check --diff inorbit_connector
     coverage run -m pytest
     coverage html -d {envlogdir}/coverage


### PR DESCRIPTION
# Description

- Bump `inorbit_edge` version to 1.20.1
- Fix `tox` command to properly run `flake8` locally