### PR TITLE
Publish map labels

### DIFF
--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -26,6 +26,7 @@ my-example-robot:
     frameIdA:
       file: ./example_map.png
       map_id: mapA
+      map_label: Building A - Floor 1
       origin_x: 0.0
       origin_y: 0.0
       resolution: 0.05

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -257,6 +257,7 @@ class Connector(ABC):
             self._robot_session.publish_map(
                 file=map_config.file,
                 map_id=map_config.map_id,
+                map_label=map_config.map_label,
                 frame_id=frame_id,
                 x=map_config.origin_x,
                 y=map_config.origin_y,

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -6,7 +6,7 @@
 # Standard
 import os
 import warnings
-from typing import List
+from typing import List, Optional
 
 # Third-party
 import pytz
@@ -36,6 +36,7 @@ class MapConfig(BaseModel):
     Attributes:
         file (FilePath): The path to the PNG map file
         map_id (str): The map id
+        map_label (str, optional): The map label
         origin_x (float): The x origin of the map
         origin_y (float): The y origin of the map
         resolution (float): The resolution
@@ -43,6 +44,7 @@ class MapConfig(BaseModel):
 
     file: FilePath
     map_id: str
+    map_label: Optional[str] = None
     origin_x: float
     origin_y: float
     resolution: float

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit_edge[video]>=1.20.1,<2.0
+inorbit_edge[video]>=1.23.0,<2.0
 pydantic>=2.6,<3.0
 pytz>=2024.1
 PyYAML>=6.0,<7.0

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -342,6 +342,7 @@ class TestConnector:
             "frameA": {
                 "file": f"{os.path.dirname(__file__)}/dir/test_map.png",
                 "map_id": "valid_map_id",
+                "map_label": "This is a map!",
                 "origin_x": 0.0,
                 "origin_y": 0.0,
                 "resolution": 0.1,
@@ -350,20 +351,32 @@ class TestConnector:
         connector = Connector("TestRobot", InorbitConnectorConfig(**base_model))
         with patch.object(connector._robot_session, "publish_map") as mock_publish:
             connector.publish_map("frameA")
-            mock_publish.assert_called_once()
+            mock_publish.assert_called_once_with(
+                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                map_id="valid_map_id",
+                map_label="This is a map!",
+                frame_id="frameA",
+                x=0.0,
+                y=0.0,
+                resolution=0.1,
+                ts=None,
+                is_update=False,
+            )
 
     def test_publish_pose_updates_maps(self, base_model):
         base_model["maps"] = {
             "frameA": {
                 "file": f"{os.path.dirname(__file__)}/dir/test_map.png",
                 "map_id": "valid_map_id",
+                "map_label": "This is a map!",
                 "origin_x": 0.0,
                 "origin_y": 0.0,
                 "resolution": 0.1,
             },
+            # The second map has no label
             "frameB": {
                 "file": f"{os.path.dirname(__file__)}/dir/test_map.png",
-                "map_id": "valid_map_id",
+                "map_id": "valid_map_id_b",
                 "origin_x": 0.0,
                 "origin_y": 0.0,
                 "resolution": 0.1,
@@ -372,11 +385,33 @@ class TestConnector:
         connector = Connector("TestRobot", InorbitConnectorConfig(**base_model))
         with patch.object(connector._robot_session, "publish_map") as mock_publish_map:
             connector.publish_pose(0, 0, 0, "frameA")
-            assert mock_publish_map.call_count == 1  # Called on first map publish
+            mock_publish_map.assert_called_once_with(
+                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                map_id="valid_map_id",
+                map_label="This is a map!",
+                frame_id="frameA",
+                x=0.0,
+                y=0.0,
+                resolution=0.1,
+                ts=None,
+                is_update=False,
+            )
+            mock_publish_map.reset_mock()
             connector.publish_pose(0, 0, 0, "frameA")
+            mock_publish_map.assert_not_called()
             assert mock_publish_map.call_count == 1  # Not called again
             connector.publish_pose(0, 0, 0, "frameB")
-            assert mock_publish_map.call_count == 2  # Called again
+            mock_publish_map.assert_called_once_with(
+                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                map_id="valid_map_id_b",
+                map_label="valid_map_id_b",
+                frame_id="frameB",
+                x=0.0,
+                y=0.0,
+                resolution=0.1,
+                ts=None,
+                is_update=False,
+            )
 
     def test_register_user_scripts(self, base_model, tmp_path):
         with patch(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -8,6 +8,7 @@ import os
 import logging
 from time import sleep
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from pathlib import Path
 
 # Third-party
 import pytest
@@ -352,7 +353,7 @@ class TestConnector:
         with patch.object(connector._robot_session, "publish_map") as mock_publish:
             connector.publish_map("frameA")
             mock_publish.assert_called_once_with(
-                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                file=Path(f"{os.path.dirname(__file__)}/dir/test_map.png"),
                 map_id="valid_map_id",
                 map_label="This is a map!",
                 frame_id="frameA",
@@ -373,7 +374,7 @@ class TestConnector:
                 "origin_y": 0.0,
                 "resolution": 0.1,
             },
-            # The second map has no label
+            # The second map has no label. The edge-sdk will treat defaults.
             "frameB": {
                 "file": f"{os.path.dirname(__file__)}/dir/test_map.png",
                 "map_id": "valid_map_id_b",
@@ -386,7 +387,7 @@ class TestConnector:
         with patch.object(connector._robot_session, "publish_map") as mock_publish_map:
             connector.publish_pose(0, 0, 0, "frameA")
             mock_publish_map.assert_called_once_with(
-                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                file=Path(f"{os.path.dirname(__file__)}/dir/test_map.png"),
                 map_id="valid_map_id",
                 map_label="This is a map!",
                 frame_id="frameA",
@@ -394,23 +395,22 @@ class TestConnector:
                 y=0.0,
                 resolution=0.1,
                 ts=None,
-                is_update=False,
+                is_update=True,
             )
             mock_publish_map.reset_mock()
             connector.publish_pose(0, 0, 0, "frameA")
             mock_publish_map.assert_not_called()
-            assert mock_publish_map.call_count == 1  # Not called again
             connector.publish_pose(0, 0, 0, "frameB")
             mock_publish_map.assert_called_once_with(
-                file=f"{os.path.dirname(__file__)}/dir/test_map.png",
+                file=Path(f"{os.path.dirname(__file__)}/dir/test_map.png"),
                 map_id="valid_map_id_b",
-                map_label="valid_map_id_b",
+                map_label=None,
                 frame_id="frameB",
                 x=0.0,
                 y=0.0,
                 resolution=0.1,
                 ts=None,
-                is_update=False,
+                is_update=True,
             )
 
     def test_register_user_scripts(self, base_model, tmp_path):


### PR DESCRIPTION
Make use of the latest [feature](https://github.com/inorbit-ai/edge-sdk-python/pull/76) of `inorbit_edge` to upload map labels.