### PR TITLE
Integrate with edge sdk to better handle online status management

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -106,6 +106,9 @@ class Connector(ABC):
             create_dir = kwargs.get("create_user_scripts_dir", False)
             self._register_user_scripts(user_scripts_path, create_dir)
 
+        # Register built-in command handlers (like get_state)
+        self._register_builtin_command_handlers()
+
         # If enabled, register the provided custom commands handler
         if kwargs.get("register_custom_command_handler", True):
             self._register_custom_command_handler(self._inorbit_command_handler)
@@ -159,6 +162,35 @@ class Connector(ABC):
                 )
 
         self._robot_session.register_command_callback(handler_wrapper)
+
+    def _register_builtin_command_handlers(self) -> None:
+        """Register built-in command handlers that all connectors need."""
+
+        def get_state_handler(command_name: str, args: list, options: dict):
+            """Handle get_state command from InOrbit."""
+            if command_name == "get_state":
+                try:
+                    is_online = self._is_robot_online()
+                    self._robot_session._send_robot_status(online=is_online)
+                    status_str = "online" if is_online else "offline"
+                    self._logger.debug(f"Responded to get_state: robot {status_str}")
+                except Exception as e:
+                    self._logger.error(f"Failed to handle get_state command: {e}")
+                    # Don't call result_function for get_state - it's not a user command
+
+        self._robot_session.register_command_callback(get_state_handler)
+
+    def _is_robot_online(self) -> bool:
+        """Check if the robot is online.
+
+        Default implementation assumes robot is online if connector is running.
+        Override this method in specific connectors to provide robot-specific
+        health checks (e.g., API connectivity, robot state, etc.).
+
+        Returns:
+            bool: True if robot is online, False otherwise.
+        """
+        return True  # Base assumption: if connector is running, robot is online
 
     @abstractmethod
     async def _inorbit_command_handler(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inorbit-edge[video]>=1.23.1,<2.0
+inorbit-edge[video]>=1.24.0,<2.0
 pydantic>=2.11,<3.0
 pytz>=2025.1
 PyYAML>=6.0.2,<7.0

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -579,3 +579,144 @@ class TestConnectorCommandHandler:
             mock_run_coroutine.assert_called_once()
             # Check the handler itself was called (which triggered the side_effect)
             mock_async_handler.assert_called()  # Check it was called at least
+
+    def test_register_builtin_command_handlers(self, base_model):
+        """Test that built-in command handlers are registered."""
+        with patch(
+            f"{Connector.__module__}.{Connector.__name__}"
+            "._register_builtin_command_handlers",
+            autospec=True,
+        ) as mock_register_builtin:
+            Connector("TestRobot", InorbitConnectorConfig(**base_model))
+            mock_register_builtin.assert_called_once()
+
+    def test_get_state_handler_responds_online_by_default(self, base_connector):
+        """Test that get_state handler responds with online status by default."""
+        connector = base_connector
+        connector._robot_session = MagicMock()
+        connector._logger = MagicMock()
+
+        # Mock _is_robot_online to return True (default behavior)
+        with patch.object(connector, "_is_robot_online", return_value=True):
+            # Get the registered handler by calling _register_builtin_command_handlers
+            # and capturing the registered callback
+            registered_callbacks = []
+            original_register = connector._robot_session.register_command_callback
+
+            def capture_callback(callback):
+                registered_callbacks.append(callback)
+                return original_register(callback)
+
+            connector._robot_session.register_command_callback = capture_callback
+            connector._register_builtin_command_handlers()
+
+            # Find the get_state handler
+            get_state_handler = None
+            for callback in registered_callbacks:
+                # Test if this callback handles get_state
+                try:
+                    callback("get_state", [], {})
+                    get_state_handler = callback
+                    break
+                except Exception:
+                    continue
+
+            assert (
+                get_state_handler is not None
+            ), "get_state handler should be registered"
+
+            # Verify it called _send_robot_status with online=True
+            connector._robot_session._send_robot_status.assert_called_with(online=True)
+
+    def test_get_state_handler_responds_offline_when_robot_offline(
+        self, base_connector
+    ):
+        """Test that get_state handler responds with offline status when robot is offline."""
+        connector = base_connector
+        connector._robot_session = MagicMock()
+        connector._logger = MagicMock()
+
+        # Mock _is_robot_online to return False
+        with patch.object(connector, "_is_robot_online", return_value=False):
+            # Get the registered handler
+            registered_callbacks = []
+            original_register = connector._robot_session.register_command_callback
+
+            def capture_callback(callback):
+                registered_callbacks.append(callback)
+                return original_register(callback)
+
+            connector._robot_session.register_command_callback = capture_callback
+            connector._register_builtin_command_handlers()
+
+            # Find and call the get_state handler
+            for callback in registered_callbacks:
+                try:
+                    callback("get_state", [], {})
+                    break
+                except Exception:
+                    continue
+
+            # Verify it called _send_robot_status with online=False
+            connector._robot_session._send_robot_status.assert_called_with(online=False)
+
+    def test_get_state_handler_ignores_other_commands(self, base_connector):
+        """Test that get_state handler ignores commands other than get_state."""
+        connector = base_connector
+        connector._robot_session = MagicMock()
+        connector._logger = MagicMock()
+
+        # Get the registered handler
+        registered_callbacks = []
+        original_register = connector._robot_session.register_command_callback
+
+        def capture_callback(callback):
+            registered_callbacks.append(callback)
+            return original_register(callback)
+
+        connector._robot_session.register_command_callback = capture_callback
+        connector._register_builtin_command_handlers()
+
+        # Call with a different command
+        for callback in registered_callbacks:
+            callback("other_command", [], {})
+
+        # Verify _send_robot_status was not called
+        connector._robot_session._send_robot_status.assert_not_called()
+
+    def test_is_robot_online_default_implementation(self, base_connector):
+        """Test that _is_robot_online returns True by default."""
+        connector = base_connector
+        assert connector._is_robot_online() is True
+
+    def test_get_state_handler_handles_exceptions(self, base_connector):
+        """Test that get_state handler handles exceptions gracefully."""
+        connector = base_connector
+        connector._robot_session = MagicMock()
+        connector._logger = MagicMock()
+
+        # Mock _is_robot_online to raise an exception
+        with patch.object(connector, "_is_robot_online", side_effect=Exception("Test error")):
+            # Get the registered handler
+            registered_callbacks = []
+            original_register = connector._robot_session.register_command_callback
+
+            def capture_callback(callback):
+                registered_callbacks.append(callback)
+                return original_register(callback)
+
+            connector._robot_session.register_command_callback = capture_callback
+            connector._register_builtin_command_handlers()
+
+            # Call the get_state handler - should not raise exception
+            for callback in registered_callbacks:
+                try:
+                    callback("get_state", [], {})
+                    break
+                except:
+                    continue
+
+            # Verify error was logged
+            connector._logger.error.assert_called()
+            # Verify _send_robot_status was not called due to exception
+            connector._robot_session._send_robot_status.assert_not_called()


### PR DESCRIPTION
Set's the edge sdk robot_session.set_online_status_callback with a default _is_robot_online() that always returns true. Allows connector's to override to set the online status based on their own logic like monitoring robot api connections health