### PR TITLE
Always publish system stats

### DIFF
--- a/docs/contents/publishing.md
+++ b/docs/contents/publishing.md
@@ -104,9 +104,11 @@ publish_system_stats(**kwargs) -> None
 publish_robot_system_stats(robot_id: str, **kwargs) -> None
 ```
 
-Stores system stats (CPU, RAM, disk usage) to be published at the end of the execution loop. If no stats are stored for a robot during the loop iteration, default zeroed values are published automatically.
+Stores system stats (CPU, RAM, disk usage) to be published at the end of the execution loop. If no stats are stored for a robot during the loop iteration, default values are published automatically.
 
 This ensures that system stats are always published for all robots in the fleet, even if the connector does not explicitly provide values. This is to ensure stability of the online status of the robot in the UI, as it forces state requests if the robot was to appear offline.
+
+By default, zeroed values are used. To use the connector host's actual system stats as defaults, set `publish_connector_system_stats=True` when initializing the connector. See [FleetConnector constructor](specification/connector#spec-connector-fleetconnector-constructor) for details.
 
 **Example:**
 ```python

--- a/docs/contents/publishing.md
+++ b/docs/contents/publishing.md
@@ -92,7 +92,7 @@ self.publish_key_values(
 )
 ```
 
-### System Statistics
+### System Stats
 
 **Single-Robot:**
 ```python
@@ -104,7 +104,9 @@ publish_system_stats(**kwargs) -> None
 publish_robot_system_stats(robot_id: str, **kwargs) -> None
 ```
 
-Publishes system statistics such as CPU, RAM, and disk usage.
+Stores system stats (CPU, RAM, disk usage) to be published at the end of the execution loop. If no stats are stored for a robot during the loop iteration, default zeroed values are published automatically.
+
+This ensures that system stats are always published for all robots in the fleet, even if the connector does not explicitly provide values. This is to ensure stability of the online status of the robot in the UI, as it forces state requests if the robot was to appear offline.
 
 **Example:**
 ```python
@@ -114,6 +116,8 @@ self.publish_system_stats(
     hdd_usage_percentage=34.1
 )
 ```
+
+> **Note:** If immediate publishing is required (bypassing the deferred behavior), use `_get_session()` (single-robot) or `_get_robot_session(robot_id)` (fleet) to access the underlying `RobotSession` and call `publish_system_stats()` directly.
 
 ## Cameras
 

--- a/docs/contents/specification/connector.md
+++ b/docs/contents/specification/connector.md
@@ -9,6 +9,17 @@ This page specifies the connector base classes you subclass to build connectors.
 
 `inorbit_connector.connector.FleetConnector` is the base class for connectors that manage multiple robots.
 
+<a id="spec-connector-fleetconnector-constructor"></a>
+### Constructor kwargs
+
+The following keyword arguments can be passed to `FleetConnector.__init__()`:
+
+- `register_user_scripts` (bool): Register user scripts automatically. Default: `False`
+- `default_user_scripts_dir` (str): Default user scripts directory path. Default: `~/.inorbit_connectors/connector-{class_name}/local/`
+- `create_user_scripts_dir` (bool): Create user scripts directory if it doesn't exist. Default: `False`
+- `register_custom_command_handler` (bool): Register custom command handler. Default: `True`
+- `publish_connector_system_stats` (bool): When `True`, publish the connector host's system stats (CPU, RAM, HDD) as default values for robots that don't provide their own stats. Requires `psutil` to be installed (`pip install inorbit-connector[system-stats]`). If `psutil` is not available, falls back to zeroed defaults with a warning. Default: `False`
+
 <a id="spec-connector-fleetconnector-connect"></a>
 ### `_connect()`
 
@@ -123,7 +134,7 @@ Publishes pose for one robot. If the `frame_id` differs from the last published 
 
 **Callable.** Stores system stats for one robot to be published at the end of the execution loop.
 
-If no stats are stored for a robot during the loop iteration, default zeroed values (`cpu_load_percentage=0.0`, `ram_usage_percentage=0.0`, `hdd_usage_percentage=0.0`) are published automatically.
+If no stats are stored for a robot during the loop iteration, default values are published automatically. By default, zeroed values are used. To use the connector host's actual system stats as defaults, set `publish_connector_system_stats=True` in the [constructor](#spec-connector-fleetconnector-constructor).
 
 If immediate publishing is required, use `_get_robot_session(robot_id)` to access the underlying `RobotSession` and call `publish_system_stats()` directly.
 

--- a/docs/contents/specification/connector.md
+++ b/docs/contents/specification/connector.md
@@ -121,7 +121,11 @@ Publishes pose for one robot. If the `frame_id` differs from the last published 
 <a id="spec-connector-fleetconnector-publish-robot-system-stats"></a>
 ### `publish_robot_system_stats(robot_id, **kwargs)`
 
-**Callable.** Publishes system stats for one robot.
+**Callable.** Stores system stats for one robot to be published at the end of the execution loop.
+
+If no stats are stored for a robot during the loop iteration, default zeroed values (`cpu_load_percentage=0.0`, `ram_usage_percentage=0.0`, `hdd_usage_percentage=0.0`) are published automatically.
+
+If immediate publishing is required, use `_get_robot_session(robot_id)` to access the underlying `RobotSession` and call `publish_system_stats()` directly.
 
 <a id="spec-connector-fleetconnector-get-robot-session"></a>
 ### `_get_robot_session(robot_id) -> RobotSession`

--- a/docs/contents/specification/index.md
+++ b/docs/contents/specification/index.md
@@ -59,14 +59,14 @@ The table below lists package-defined symbols meant for direct use (call) or ext
 | Call | `FleetConnector.publish_robot_map()` | Publish map metadata/image from configured maps (or after fetch). | [Details](connector.md#spec-connector-fleetconnector-publish-robot-map) |
 | Call | `FleetConnector.publish_robot_odometry()` | Publish odometry. | [Details](connector.md#spec-connector-fleetconnector-publish-robot-odometry) |
 | Call | `FleetConnector.publish_robot_key_values()` | Publish key-value telemetry. | [Details](connector.md#spec-connector-fleetconnector-publish-robot-key-values) |
-| Call | `FleetConnector.publish_robot_system_stats()` | Publish system stats telemetry. | [Details](connector.md#spec-connector-fleetconnector-publish-robot-system-stats) |
+| Call | `FleetConnector.publish_robot_system_stats()` | Defer publishing of system stats for a specific robot; defaults are published if not called. | [Details](connector.md#spec-connector-fleetconnector-publish-robot-system-stats) |
 | Call (advanced) | `FleetConnector._get_robot_session()` | Access the underlying Edge SDK `RobotSession` for a specific robot. | [Details](connector.md#spec-connector-fleetconnector-get-robot-session) |
 | Override | `Connector._connect()` / `_execution_loop()` / `_disconnect()` | Same lifecycle hooks as fleet, for a single robot. | [Details](connector.md#spec-connector-connector-lifecycle-hooks) |
 | Override | `Connector._inorbit_command_handler()` | Handle commands for the single robot. | [Details](connector.md#spec-connector-connector-command-handler) |
 | Override (optional) | `Connector.fetch_map()` | Fetch a missing map for the current robot when pose references an unknown `frame_id`. | [Details](connector.md#spec-connector-connector-fetch-map) |
 | Override (optional) | `Connector._is_robot_online()` | Provide online status for the current robot. | [Details](connector.md#spec-connector-connector-is-online) |
 | Call | `Connector.publish_pose()` / `publish_map()` | Publish pose/map for the current robot (map handling included). | [Details](connector.md#spec-connector-connector-publishing) |
-| Call | `Connector.publish_odometry()` / `publish_key_values()` / `publish_system_stats()` | Publish telemetry for the current robot. | [Details](connector.md#spec-connector-connector-publishing) |
+| Call | `Connector.publish_odometry()` / `publish_key_values()` / `publish_system_stats()` | Publish telemetry for the current robot. `publish_system_stats()` defers publishing; defaults published if not called. | [Details](connector.md#spec-connector-connector-publishing) |
 | Call (advanced) | `Connector._get_session()` | Access the underlying Edge SDK `RobotSession` for the current robot. | [Details](connector.md#spec-connector-connector-get-session) |
 | Type | `ConnectorConfig` | Base configuration model for connectors. | [Details](models.md#spec-models-connectorconfig) |
 | Type | `RobotConfig` | Per-robot configuration (robot_id + cameras). | [Details](models.md#spec-models-robotconfig) |

--- a/docs/contents/usage/fleet.md
+++ b/docs/contents/usage/fleet.md
@@ -95,7 +95,7 @@ All publishing methods require a `robot_id` parameter. See the [Publishing Guide
 - `publish_robot_pose(robot_id, x, y, yaw, frame_id)`: Publish pose for a specific robot
 - `publish_robot_odometry(robot_id, **kwargs)`: Publish odometry for a specific robot
 - `publish_robot_key_values(robot_id, **kwargs)`: Publish key-values for a specific robot
-- `publish_robot_system_stats(robot_id, **kwargs)`: Publish system stats for a specific robot
+- `publish_robot_system_stats(robot_id, **kwargs)`: Defer publishing of system stats for a specific robot; defaults are published if not called
 - `publish_robot_map(robot_id, frame_id, is_update=False)`: Publish map for a specific robot
 
 ## Advanced Methods

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -34,6 +34,15 @@ from inorbit_edge.models import RobotSessionModel
 from inorbit_edge.robot import RobotSession, RobotSessionPool, RobotSessionFactory
 from inorbit_edge.video import OpenCVCamera
 
+# Optional dependency for connector system stats
+try:
+    import psutil
+
+    PSUTIL_AVAILABLE = True
+except ImportError:
+    psutil = None
+    PSUTIL_AVAILABLE = False
+
 # InOrbit
 from inorbit_connector.commands import (  # noqa: F401
     # Re-export command-related functionality for backwards compatibility
@@ -80,6 +89,11 @@ class FleetConnector(ABC):
                 Default is False
             register_custom_command_handler (bool): Register custom command handler.
                 Default is True
+            publish_connector_system_stats (bool): When True, publish the connector
+                host's system stats (CPU, RAM, HDD) as default values in cases where the
+                implementation doesn't provide their own stats.
+                Requires psutil to be installed (pip install inorbit-connector[system-stats]).
+                Default is False (zeroed defaults)
         """
 
         # Common information
@@ -129,6 +143,18 @@ class FleetConnector(ABC):
         # Logging information
         setup_logger(config.logging)
         self._logger = logging.getLogger(__name__)
+
+        # System stats default behavior
+        self.__publish_connector_system_stats = kwargs.get(
+            "publish_connector_system_stats", False
+        )
+        if self.__publish_connector_system_stats and not PSUTIL_AVAILABLE:
+            self._logger.warning(
+                "publish_connector_system_stats requires psutil. "
+                "Install with: pip install inorbit-connector[system-stats]. "
+                "Falling back to zeroed defaults."
+            )
+            self.__publish_connector_system_stats = False
 
         # Set up environment variables
         for env_var_name, env_var_value in config.env_vars.items():
@@ -675,29 +701,50 @@ class FleetConnector(ABC):
         """
         self.__pending_system_stats[robot_id] = kwargs
 
+    def __get_connector_system_stats(self) -> dict:
+        """Get system stats from the connector's host environment.
+
+        Returns:
+            dict: System stats with cpu_load_percentage, ram_usage_percentage,
+                and hdd_usage_percentage as floats between 0.0 and 1.0.
+        """
+        return {
+            "cpu_load_percentage": psutil.cpu_percent() / 100.0,
+            "ram_usage_percentage": psutil.virtual_memory().percent / 100.0,
+            "hdd_usage_percentage": psutil.disk_usage("/").percent / 100.0,
+        }
+
     def __publish_pending_system_stats(self) -> None:
         """Publish stored system stats for all robots, or defaults if none stored.
 
         This method is called automatically at the end of each execution loop iteration.
         For each robot in the fleet:
         - If system stats were stored via publish_robot_system_stats(), those are published
-        - Otherwise, default zeroed values are published
+        - Otherwise, default values are published (connector host stats if
+          publish_connector_system_stats is enabled, zeroed values otherwise).
 
         The reason publishing system stats is deferred is to ensure at least one system stats
         message is published for each robot, even if the connector does not explicitly provide
         values. This ensures stability of the online status of the robot in the UI, as it forces
         state requests if the robot was to appear offline.
         """
+        default_values = (
+            self.__get_connector_system_stats()
+            if self.__publish_connector_system_stats
+            else {
+                "cpu_load_percentage": 0.0,
+                "ram_usage_percentage": 0.0,
+                "hdd_usage_percentage": 0.0,
+            }
+        )
+
         for robot_id in self.robot_ids:
             session = self._get_robot_session(robot_id)
-            if robot_id in self.__pending_system_stats:
-                session.publish_system_stats(**self.__pending_system_stats[robot_id])
+            if pending_status := self.__pending_system_stats.get(robot_id):
+                session.publish_system_stats(**pending_status)
             else:
-                session.publish_system_stats(
-                    cpu_load_percentage=0.0,
-                    ram_usage_percentage=0.0,
-                    hdd_usage_percentage=0.0,
-                )
+                session.publish_system_stats(**default_values)
+
         # Clear stored stats for next iteration
         self.__pending_system_stats.clear()
 

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -92,7 +92,8 @@ class FleetConnector(ABC):
             publish_connector_system_stats (bool): When True, publish the connector
                 host's system stats (CPU, RAM, HDD) as default values in cases where the
                 implementation doesn't provide their own stats.
-                Requires psutil to be installed (pip install inorbit-connector[system-stats]).
+                Requires psutil to be installed with
+                    `pip install inorbit-connector[system-stats]`.
                 Default is False (zeroed defaults)
         """
 
@@ -692,7 +693,8 @@ class FleetConnector(ABC):
 
         Note:
             If immediate publishing is required, use `_get_robot_session(robot_id)` to
-            access the underlying RobotSession and call `publish_system_stats()` directly.
+            access the underlying RobotSession and call `publish_system_stats()`
+            directly.
 
         Args:
             robot_id (str): The robot ID to store system stats for
@@ -719,14 +721,15 @@ class FleetConnector(ABC):
 
         This method is called automatically at the end of each execution loop iteration.
         For each robot in the fleet:
-        - If system stats were stored via publish_robot_system_stats(), those are published
+        - If system stats were stored via publish_robot_system_stats(), those are
+        published
         - Otherwise, default values are published (connector host stats if
           publish_connector_system_stats is enabled, zeroed values otherwise).
 
-        The reason publishing system stats is deferred is to ensure at least one system stats
-        message is published for each robot, even if the connector does not explicitly provide
-        values. This ensures stability of the online status of the robot in the UI, as it forces
-        state requests if the robot was to appear offline.
+        The reason publishing system stats is deferred is to ensure at least one system
+        stats message is published for each robot, even if the connector does not
+        explicitly provide values. This ensures stability of the online status of the
+        robot in the UI, as it forces state requests if the robot was to appear offline.
         """
         default_values = (
             self.__get_connector_system_stats()

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -94,6 +94,8 @@ class FleetConnector(ABC):
 
         # Per robot state
         self.__last_published_frame_ids: dict[str, str] = {}
+        # Store system stats per robot until end of the execution loop
+        self.__pending_system_stats: dict[str, dict] = {}
         # Track pending map fetches to avoid duplicate requests
         self.__pending_map_fetches: set[str] = set()
         self.__pending_map_fetches_lock = threading.Lock()
@@ -390,6 +392,8 @@ class FleetConnector(ABC):
                     self._execution_loop(),
                     asyncio.sleep(1.0 / self.config.update_freq),
                 )
+                # Publish stored system stats or defaults for all robots
+                self.__publish_pending_system_stats()
             except Exception as e:
                 self._logger.error(f"Error in execution loop: {e}")
                 self._logger.error(f"Traceback: {traceback.format_exc()}")
@@ -654,14 +658,48 @@ class FleetConnector(ABC):
         session.publish_key_values(kwargs)
 
     def publish_robot_system_stats(self, robot_id: str, **kwargs) -> None:
-        """Publish system stats for a specific robot to InOrbit.
+        """Store system stats for a specific robot to be published at the end of the
+        execution loop.
+
+        System stats are stored and published after the execution loop completes. If no
+        stats are stored for a robot, default zeroed values are published instead.
+
+        Note:
+            If immediate publishing is required, use `_get_robot_session(robot_id)` to
+            access the underlying RobotSession and call `publish_system_stats()` directly.
 
         Args:
-            robot_id (str): The robot ID to publish system stats for
-            **kwargs: System stats data
+            robot_id (str): The robot ID to store system stats for
+            **kwargs: System stats data (cpu_load_percentage, ram_usage_percentage,
+                hdd_usage_percentage, ts)
         """
-        session = self._get_robot_session(robot_id)
-        session.publish_system_stats(**kwargs)
+        self.__pending_system_stats[robot_id] = kwargs
+
+    def __publish_pending_system_stats(self) -> None:
+        """Publish stored system stats for all robots, or defaults if none stored.
+
+        This method is called automatically at the end of each execution loop iteration.
+        For each robot in the fleet:
+        - If system stats were stored via publish_robot_system_stats(), those are published
+        - Otherwise, default zeroed values are published
+
+        The reason publishing system stats is deferred is to ensure at least one system stats
+        message is published for each robot, even if the connector does not explicitly provide
+        values. This ensures stability of the online status of the robot in the UI, as it forces
+        state requests if the robot was to appear offline.
+        """
+        for robot_id in self.robot_ids:
+            session = self._get_robot_session(robot_id)
+            if robot_id in self.__pending_system_stats:
+                session.publish_system_stats(**self.__pending_system_stats[robot_id])
+            else:
+                session.publish_system_stats(
+                    cpu_load_percentage=0.0,
+                    ram_usage_percentage=0.0,
+                    hdd_usage_percentage=0.0,
+                )
+        # Clear stored stats for next iteration
+        self.__pending_system_stats.clear()
 
     # Methods meant to be extended by subclasses
     @abstractmethod
@@ -929,9 +967,17 @@ class Connector(FleetConnector, ABC):
         super().publish_robot_key_values(self.robot_id, **kwargs)
 
     def publish_system_stats(self, **kwargs) -> None:
-        """Publish system stats for a specific robot to InOrbit.
+        """Store system stats to be published at the end of the execution loop.
+
+        System stats are stored and published after the execution loop completes. If no
+        stats are stored, default zeroed values are published instead.
+
+        Note:
+            If immediate publishing is required, use `_get_session()` to access the
+            underlying RobotSession and call `publish_system_stats()` directly.
 
         Args:
-            **kwargs: System stats data
+            **kwargs: System stats data (cpu_load_percentage, ram_usage_percentage,
+                hdd_usage_percentage, ts)
         """
         super().publish_robot_system_stats(self.robot_id, **kwargs)

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -424,6 +424,7 @@ class FleetConnector(ABC):
             except Exception as e:
                 self._logger.error(f"Error in execution loop: {e}")
                 self._logger.error(f"Traceback: {traceback.format_exc()}")
+                self.__pending_system_stats.clear()
                 # Continue execution after a brief pause to avoid tight error loops
                 await asyncio.sleep(1.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ docs = [
 colorlog = [
     "colorlog==6.9.0",
 ]
+system-stats = [
+    "psutil>=7",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -267,16 +267,21 @@ class TestFleetConnector:
         session = base_fleet_connector._get_robot_session(robot_id)
         session.publish_key_values.assert_called()
 
-    def test_publish_robot_system_stats(
+    def test_publish_robot_system_stats_stores_stats(
         self, base_fleet_connector, mock_robot_session_pool
     ):
-        """Test publishing system stats for a specific robot."""
+        """Test that publish_robot_system_stats stores stats instead of publishing."""
         robot_id = "TestRobot1"
         base_fleet_connector.publish_robot_system_stats(
             robot_id, cpu_load_percentage=50.0
         )
+        # Stats should be stored, not published immediately
         session = base_fleet_connector._get_robot_session(robot_id)
-        session.publish_system_stats.assert_called()
+        session.publish_system_stats.assert_not_called()
+        # Verify stats were stored
+        pending_stats = base_fleet_connector._FleetConnector__pending_system_stats
+        assert robot_id in pending_stats
+        assert pending_stats[robot_id]["cpu_load_percentage"] == 50.0
 
     def test_is_fleet_robot_online_default(self, base_fleet_connector):
         """Test that _is_fleet_robot_online returns True by default."""
@@ -495,6 +500,207 @@ class TestFleetConnectorMapFetching:
         # Verify temp dir was cleaned up
         assert fleet_connector._FleetConnector__temp_map_dir is None
         assert not temp_dir.exists()
+
+
+class TestFleetConnectorDeferredSystemStats:
+    """Tests for FleetConnector deferred system stats publishing."""
+
+    @pytest.fixture
+    def base_model(self):
+        return {
+            "api_key": "valid_key",
+            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connector_type": "valid_connector",
+            "connector_config": DummyConfig(),
+        }
+
+    @pytest.fixture(autouse=True)
+    def make_fleet_connector_not_abstract(self):
+        FleetConnector.__abstractmethods__ = set()
+
+    @pytest.fixture
+    def fleet_connector(self, base_model):
+        return FleetConnector(
+            ConnectorConfig(
+                **base_model,
+                fleet=[
+                    RobotConfig(robot_id="TestRobot1"),
+                    RobotConfig(robot_id="TestRobot2"),
+                ],
+            )
+        )
+
+    def test_publish_pending_system_stats_publishes_stored_stats(
+        self, fleet_connector, mock_robot_session_pool
+    ):
+        """Test that stored stats are published for robots that provided them."""
+        # Store stats for TestRobot1
+        fleet_connector.publish_robot_system_stats(
+            "TestRobot1",
+            cpu_load_percentage=0.5,
+            ram_usage_percentage=0.6,
+            hdd_usage_percentage=0.7,
+        )
+
+        # Call the publish method
+        fleet_connector._FleetConnector__publish_pending_system_stats()
+
+        # Verify stored stats were published for TestRobot1
+        session1 = fleet_connector._get_robot_session("TestRobot1")
+        session1.publish_system_stats.assert_called_once_with(
+            cpu_load_percentage=0.5,
+            ram_usage_percentage=0.6,
+            hdd_usage_percentage=0.7,
+        )
+
+    def test_publish_pending_system_stats_publishes_zeroed_defaults(
+        self, fleet_connector, mock_robot_session_pool
+    ):
+        """Test that zeroed defaults are published for robots without stored stats."""
+        # Don't store any stats, just call publish
+        fleet_connector._FleetConnector__publish_pending_system_stats()
+
+        # Verify zeroed defaults were published for both robots
+        session1 = fleet_connector._get_robot_session("TestRobot1")
+        session2 = fleet_connector._get_robot_session("TestRobot2")
+
+        session1.publish_system_stats.assert_called_once_with(
+            cpu_load_percentage=0.0,
+            ram_usage_percentage=0.0,
+            hdd_usage_percentage=0.0,
+        )
+        session2.publish_system_stats.assert_called_once_with(
+            cpu_load_percentage=0.0,
+            ram_usage_percentage=0.0,
+            hdd_usage_percentage=0.0,
+        )
+
+    def test_publish_pending_system_stats_clears_stored_stats(
+        self, fleet_connector, mock_robot_session_pool
+    ):
+        """Test that stored stats are cleared after publishing."""
+        fleet_connector.publish_robot_system_stats(
+            "TestRobot1", cpu_load_percentage=0.5
+        )
+        assert "TestRobot1" in fleet_connector._FleetConnector__pending_system_stats
+
+        fleet_connector._FleetConnector__publish_pending_system_stats()
+
+        # Verify stats were cleared
+        assert len(fleet_connector._FleetConnector__pending_system_stats) == 0
+
+    def test_publish_pending_system_stats_mixed_stored_and_default(
+        self, fleet_connector, mock_robot_session_pool
+    ):
+        """Test that stored stats are used for some robots, defaults for others."""
+        # Store stats only for TestRobot1
+        fleet_connector.publish_robot_system_stats(
+            "TestRobot1",
+            cpu_load_percentage=0.8,
+            ram_usage_percentage=0.9,
+            hdd_usage_percentage=0.1,
+        )
+
+        fleet_connector._FleetConnector__publish_pending_system_stats()
+
+        # TestRobot1 should have stored stats
+        session1 = fleet_connector._get_robot_session("TestRobot1")
+        session1.publish_system_stats.assert_called_once_with(
+            cpu_load_percentage=0.8,
+            ram_usage_percentage=0.9,
+            hdd_usage_percentage=0.1,
+        )
+
+        # TestRobot2 should have zeroed defaults
+        session2 = fleet_connector._get_robot_session("TestRobot2")
+        session2.publish_system_stats.assert_called_once_with(
+            cpu_load_percentage=0.0,
+            ram_usage_percentage=0.0,
+            hdd_usage_percentage=0.0,
+        )
+
+    def test_publish_connector_system_stats_uses_psutil(
+        self, base_model, mock_robot_session_pool
+    ):
+        """Test that connector host stats are used when enabled and psutil available."""
+        with patch("inorbit_connector.connector.PSUTIL_AVAILABLE", True):
+            with patch("inorbit_connector.connector.psutil") as mock_psutil:
+                # Mock psutil functions
+                mock_psutil.cpu_percent.return_value = 50.0
+                mock_psutil.virtual_memory.return_value.percent = 60.0
+                mock_psutil.disk_usage.return_value.percent = 70.0
+
+                connector = FleetConnector(
+                    ConnectorConfig(
+                        **base_model,
+                        fleet=[RobotConfig(robot_id="TestRobot1")],
+                    ),
+                    publish_connector_system_stats=True,
+                )
+
+                connector._FleetConnector__publish_pending_system_stats()
+
+                session = connector._get_robot_session("TestRobot1")
+                session.publish_system_stats.assert_called_once_with(
+                    cpu_load_percentage=0.5,  # 50.0 / 100.0
+                    ram_usage_percentage=0.6,  # 60.0 / 100.0
+                    hdd_usage_percentage=0.7,  # 70.0 / 100.0
+                )
+
+    def test_publish_connector_system_stats_fallback_without_psutil(
+        self, base_model, mock_robot_session_pool
+    ):
+        """Test fallback to zeroed defaults when psutil not available."""
+        with patch("inorbit_connector.connector.PSUTIL_AVAILABLE", False):
+            connector = FleetConnector(
+                ConnectorConfig(
+                    **base_model,
+                    fleet=[RobotConfig(robot_id="TestRobot1")],
+                ),
+                publish_connector_system_stats=True,
+            )
+
+            # Should have fallen back to False
+            assert connector._FleetConnector__publish_connector_system_stats is False
+
+            connector._FleetConnector__publish_pending_system_stats()
+
+            # Should use zeroed defaults
+            session = connector._get_robot_session("TestRobot1")
+            session.publish_system_stats.assert_called_once_with(
+                cpu_load_percentage=0.0,
+                ram_usage_percentage=0.0,
+                hdd_usage_percentage=0.0,
+            )
+
+    def test_publish_connector_system_stats_logs_warning_without_psutil(
+        self, base_model, mock_robot_session_pool
+    ):
+        """Test that warning is logged when psutil not available but feature enabled."""
+        with patch("inorbit_connector.connector.PSUTIL_AVAILABLE", False):
+            with patch("inorbit_connector.connector.logging") as mock_logging:
+                mock_logger = MagicMock()
+                mock_logging.getLogger.return_value = mock_logger
+
+                FleetConnector(
+                    ConnectorConfig(
+                        **base_model,
+                        fleet=[RobotConfig(robot_id="TestRobot1")],
+                    ),
+                    publish_connector_system_stats=True,
+                )
+
+                # Verify warning was logged
+                mock_logger.warning.assert_called()
+                warning_msg = mock_logger.warning.call_args[0][0]
+                assert "psutil" in warning_msg
+                assert "inorbit-connector[system-stats]" in warning_msg
+
+    def test_publish_connector_system_stats_disabled_by_default(
+        self, fleet_connector, mock_robot_session_pool
+    ):
+        """Test that connector system stats are disabled by default."""
+        assert fleet_connector._FleetConnector__publish_connector_system_stats is False
 
 
 # ==============================================================================
@@ -717,12 +923,20 @@ class TestConnector:
         session.publish_key_values.assert_called()
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_publish_system_stats(self, base_connector, mock_robot_session_pool):
-        """Test publish_system_stats delegates correctly."""
+    def test_publish_system_stats_stores_stats(
+        self, base_connector, mock_robot_session_pool
+    ):
+        """Test publish_system_stats stores stats for deferred publishing."""
         base_connector.publish_system_stats(cpu_load_percentage=50.0)
 
+        # Stats should be stored, not published immediately
         session = base_connector._get_session()
-        session.publish_system_stats.assert_called()
+        session.publish_system_stats.assert_not_called()
+
+        # Verify stats were stored
+        pending_stats = base_connector._FleetConnector__pending_system_stats
+        assert base_connector.robot_id in pending_stats
+        assert pending_stats[base_connector.robot_id]["cpu_load_percentage"] == 50.0
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_is_robot_online_default_implementation(self, base_connector):


### PR DESCRIPTION
## Summary

Implement deferred system stats publishing with automatic defaults to ensure robots maintain stable online status in the InOrbit UI.

## Changes

- **Deferred publishing**: `publish_robot_system_stats()` and `publish_system_stats()` now store stats during the execution loop and publish them afterward
- **Automatic defaults**: If a robot doesn't provide stats, default values are published automatically (zeroed by default)
- **Opt-in connector stats**: New `publish_connector_system_stats` kwarg enables using the connector host's actual CPU/RAM/HDD as defaults (requires `psutil`)
- **Optional dependency**: Added `psutil>=7` as optional `[system-stats]` extra
- **Comprehensive tests**: Added 8 new tests covering deferred publishing, default values, psutil integration, and fallback behavior
- **Updated documentation**: Updated publishing guide and API specification to reflect new behavior

## Motivation

This ensures at least one system stats message is published per robot per loop iteration, which helps maintain stable robot online status in the UI by forcing backend state requests when needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces deferred system stats publishing with automatic defaults and optional connector-host metrics.
> 
> - `publish_robot_system_stats()` / `publish_system_stats()` now buffer stats per loop and publish via `__publish_pending_system_stats()`; if none provided, defaults are published
> - New `publish_connector_system_stats` kwarg uses host `psutil` CPU/RAM/HDD as defaults; falls back to zeroed values with a warning when unavailable
> - Adds optional `[system-stats]` extra (`psutil>=7`) in `pyproject.toml`
> - Updates docs (Publishing, Connector spec, Fleet usage) to reflect deferred behavior and configuration; minor heading rename to `System Stats`
> - Adds comprehensive tests covering deferred flow, defaults, psutil usage/fallback, and logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b70f34d66e2e267bfbfec8860db1e2fdd633925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->