### PR TITLE
Add cookiecutter template information

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) file for information on how to develo
 
 The [`examples`](examples) directory contains usage examples of the connector. See [examples/README](examples/README.md) for more information.
 
+A cookiecutter template is available for quickly generating a new connector project. See [`inorbit-connector-cookiecutter`](https://github.com/inorbit-ai/inorbit-connector-cookiecutter) for more information.
+
 ## Contributing
 
 Any contribution that you make to this repository will be under the MIT license, as dictated by that [license](https://opensource.org/licenses/MIT).

--- a/docs/contents/getting-started.md
+++ b/docs/contents/getting-started.md
@@ -3,6 +3,20 @@ title: "Getting Started"
 description: "Installation and setup for the InOrbit Connector Framework"
 ---
 
+## Quick Start
+
+A cookiecutter template is available for quickly generating a new connector project. See [`inorbit-connector-cookiecutter`](https://github.com/inorbit-ai/inorbit-connector-cookiecutter) for more information.
+
+To generate a new connector project:
+
+1. Create a new repository and `cd` into it.
+2. Run `pipx run cookiecutter gh:inorbit-ai/inorbit-connector-cookiecutter`. This will install the [cookiecutter package](https://cookiecutter.readthedocs.io/) if you don't have it already and download the InOrbit connector cookiecutter.
+3. Follow the prompts to create a new connector.
+4. Once all questions are answered, the cookiecutter will generate a bunch of files and directories for you to start working on your connector.
+5. Read the notice at the top of the generated README.md file and follow the instructions to complete the setup.
+
+Continue reading for a complete usage guide and examples.
+
 ## Installation
 
 There are two ways of installing the `inorbit-connector` Python package.


### PR DESCRIPTION
## Description

- Introduced a references to [`inorbit-ai/inorbit-connector-cookiecutter`](https://github.com/inorbit-ai/inorbit-connector-cookiecutter) for quickly generating new connector projects in both README.md and getting-started.md.
- Provided step-by-step instructions for using the cookiecutter template to streamline project setup.