### PR TITLE
Clarify online status callback invocation context

### DIFF
--- a/docs/contents/specification/connector.md
+++ b/docs/contents/specification/connector.md
@@ -83,7 +83,7 @@ Return `None` if the map can’t be fetched.
 
 **Optional override.**
 
-The Edge SDK uses this callback to determine if a robot should be considered online. Default implementation returns `True`.
+The Edge SDK uses this callback to determine if a robot should be considered online. It is invoked when InOrbit sends a `get_state` request, which happens automatically when the robot is marked as offline but system stats are still being received. Default implementation returns `True`.
 
 <a id="spec-connector-fleetconnector-lifecycle"></a>
 ### `start()` / `join()` / `stop()`
@@ -177,7 +177,7 @@ Single-robot convenience for map fetching. The framework uses it by delegating `
 
 **Optional override.**
 
-Single-robot convenience for online status. The fleet-level online check delegates to this method.
+Single-robot convenience for online status. The fleet-level online check delegates to this method. Called when InOrbit requests state due to a discrepancy between the robot's offline status and incoming system stats.
 
 <a id="spec-connector-connector-publishing"></a>
 ### Publishing wrappers

--- a/docs/contents/usage/fleet.md
+++ b/docs/contents/usage/fleet.md
@@ -138,7 +138,7 @@ def _is_fleet_robot_online(self, robot_id: str) -> bool:
     return self._fleet_manager.is_robot_online(robot_id)
 ```
 
-This is used by InOrbit to determine robot availability.
+This callback is invoked when InOrbit sends a `get_state` request, which happens automatically when the robot is marked as offline but system stats are still being received. The connector framework always publishes system stats for all robots (even zeroed defaults), ensuring that any online/offline discrepancy is detected and corrected.
 
 ## Example Execution Loop
 

--- a/docs/contents/usage/single-robot.md
+++ b/docs/contents/usage/single-robot.md
@@ -156,7 +156,7 @@ async def _execution_loop(self) -> None:
 
 ### `_is_robot_online()`
 
-Override this method to provide custom robot health checks. The default implementation assumes the robot is online if the connector is running.
+Override this method to provide custom robot health checks. The default implementation assumes the robot is online if the connector is running. This callback is invoked when InOrbit sends a `get_state` request, which happens automatically when the robot is marked as offline but system stats are still being received.
 
 ```python
 def _is_robot_online(self) -> bool:

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -820,9 +820,12 @@ class FleetConnector(ABC):
     def _is_fleet_robot_online(self, robot_id: str) -> bool:
         """Check if a specific robot is online.
 
-        Default implementation assumes robot is online if connector is running.
-        Override this method in specific connectors to provide robot-specific
-        health checks (e.g., API connectivity, robot state, etc.).
+        Default implementation assumes robot is online if the connector is running.
+        Override this method in specific connectors to provide robot-specific health
+        checks (e.g., API connectivity, robot state, etc.).
+
+        NOTE: State will automatically be requested from InOrbit if the robot is marked
+        as offline but system stats are sent.
 
         Args:
             robot_id (str): The robot ID to check
@@ -904,6 +907,9 @@ class Connector(FleetConnector, ABC):
         Default implementation assumes robot is online if connector is running.
         Override this method in specific connectors to provide robot-specific
         health checks (e.g., API connectivity, robot state, etc.).
+
+        NOTE: State will automatically be requested from InOrbit if the robot is marked
+        as offline but system stats are sent.
 
         Returns:
             bool: True if robot is online, False otherwise.


### PR DESCRIPTION
## Summary

Add documentation explaining when `_is_robot_online` and `_is_fleet_robot_online` callbacks are invoked: on `get_state` requests triggered when InOrbit detects a discrepancy between the robot's offline status and incoming system stats.

### Changes

- **connector.py**: Add NOTE to `_is_fleet_robot_online` and `_is_robot_online` docstrings
- **specification/connector.md**: Add invocation context to both method descriptions
- **usage/fleet.md**: Replace vague description with accurate explanation of the mechanism
- **usage/single-robot.md**: Add invocation context to `_is_robot_online()` section

Made with [Cursor](https://cursor.com)