### PR TITLE
Fix map fetch log flooding when frame_id has no map

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -522,6 +522,7 @@ class FleetConnector(ABC):
             self._logger.info(
                 f"Updating map {frame_id} with new pose for robot {robot_id}."
             )
+            self.__last_published_frame_ids[robot_id] = frame_id
             self.publish_robot_map(robot_id, frame_id, is_update=True)
         session.publish_pose(x, y, yaw, frame_id, **kwargs)
 
@@ -553,7 +554,6 @@ class FleetConnector(ABC):
                 is_update=is_update,
                 format_version=map_config.format_version,
             )
-            self.__last_published_frame_ids[robot_id] = frame_id
         else:
             # Map not in config - schedule async fetch if not already pending
             self._schedule_map_fetch(robot_id, frame_id, is_update)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -245,6 +245,29 @@ class TestFleetConnector:
         session.publish_map.assert_called_once()
         session.publish_pose.assert_called_once()
 
+    def test_publish_robot_pose_no_map_logs_once(
+        self, base_fleet_connector, mock_robot_session_pool
+    ):
+        """Test that pose with unknown frame_id only triggers map update once."""
+        robot_id = "TestRobot1"
+        mock_loop = MagicMock()
+        mock_loop.is_running.return_value = True
+        base_fleet_connector._FleetConnector__loop = mock_loop
+
+        with patch("asyncio.run_coroutine_threadsafe"):
+            base_fleet_connector.publish_robot_pose(
+                robot_id, 1.0, 2.0, 0.0, "unknown_frame"
+            )
+            base_fleet_connector.publish_robot_pose(
+                robot_id, 3.0, 4.0, 0.0, "unknown_frame"
+            )
+
+        session = base_fleet_connector._get_robot_session(robot_id)
+        # publish_map never called (map not in config)
+        session.publish_map.assert_not_called()
+        # publish_pose called both times
+        assert session.publish_pose.call_count == 2
+
     def test_publish_robot_odometry(
         self, base_fleet_connector, mock_robot_session_pool
     ):


### PR DESCRIPTION
## Summary

Fixes an issue where when `publish_robot_pose` is called with a frame_id that has no map configured (not in YAML and `fetch_robot_map` returns None), three INFO log lines repeated every cycle (~1/sec)

**Root cause:** `__last_published_frame_ids` was only updated on successful map publish

**Fix**: move the tracking update into `publish_robot_pose` so it fires unconditionally on frame change, logging only once and staying quiet until the frame_id actually changes.

## Demo

Commenting out the map section from example.yaml and running `simple-example` would produce three INFO logs per second.

https://github.com/inorbit-ai/inorbit-connector-python/blob/35b7052d39ba349a1a667891d8a5abf6c12b330a/examples/example.yaml#L28-L35

Updated behavior:
```
❯ python simple-connector/connector.py
INFO:main:Configuration loaded and validated for my-example-robot
        connector_config: {"example_bot_api_version":"v1","example_bot_hw_rev":"v3","example_bot_custom_value":"test123"}
INFO:main:Starting connector...
09:55:03 INFO [inorbit_connector.connector] This is an info message ℹ️ (connector.py:116)
09:55:03 WARNING [inorbit_connector.connector] This is a warning message ⚠️ (connector.py:117)
09:55:03 ERROR [inorbit_connector.connector] This is an error message ❌ (connector.py:118)
09:55:03 CRITICAL [inorbit_connector.connector] This is a critical message 💥 (connector.py:119)
09:55:03 INFO [inorbit_connector.connector] Connected to robot services at API v1 (connector.py:126)
09:55:03 INFO [RobotSession] Registering callback 'command_callback' for robot 'my-example-robot' (robot.py:1060)
09:55:03 INFO [RobotSession] Fetching config for robot my-example-robot (robot.py:552)
09:55:03 INFO [RobotSession] Waiting for MQTT connection state '_is_connected' ... (robot.py:1145)
09:55:03 INFO [RobotSession] Connected to MQTT (robot.py:594)
09:55:04 INFO [RobotSession] MQTT connection initiated. localdev.com:1883 (MQTT) (robot.py:1198)
09:55:04 INFO [RobotSession] Registering callback 'handler_wrapper' for robot 'my-example-robot' (robot.py:1060)
09:55:04 INFO [inorbit_connector.connector] Initialized 1 robot sessions for robots my-example-robot (connector.py:330)
09:55:04 INFO [inorbit_connector.connector] Updating map frameIdA with new pose for robot my-example-robot. (connector.py:522)
09:55:04 INFO [inorbit_connector.connector] Map frameIdA not in configuration, scheduling async fetch (connector.py:602)
09:55:04 INFO [inorbit_connector.connector] Map frameIdA could not be fetched from robot my-example-robot (connector.py:624)
09:55:04 INFO [inorbit_connector.connector] Robot data updated and published (connector.py:180)
09:55:05 INFO [inorbit_connector.connector] Robot data updated and published (connector.py:180)
09:55:06 INFO [inorbit_connector.connector] Robot data updated and published (connector.py:180)
[...etc.]
```