### PR TITLE
Make video an opt-in extra to avoid forcing OpenCV install

### DIFF
--- a/docs/contents/publishing.md
+++ b/docs/contents/publishing.md
@@ -127,6 +127,16 @@ self.publish_system_stats(
 
 Cameras are configured in the `RobotConfig.cameras` field and are automatically registered when the connector connects.
 
+### Installing camera support
+
+Camera streaming requires OpenCV, which is not installed by default. Install the optional `video` extra when your connector needs cameras:
+
+```bash
+pip install inorbit-connector[video]
+```
+
+This pulls in `opencv-python-headless` via `inorbit-edge[video]`. Connectors that don't use cameras can omit the extra and avoid the OpenCV dependency entirely (useful on platforms like Alpine Linux where OpenCV has no prebuilt wheel).
+
 ### Camera Configuration
 
 Cameras are configured using `CameraConfig` from the InOrbit Edge SDK. Each camera in the `RobotConfig.cameras` list is automatically registered with InOrbit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "inorbit-edge[video,telemetry]>=2.1,<3.0",
+    "inorbit-edge[telemetry]>=2.1,<3.0",
     "pydantic>=2.11,<3.0",
     "pytz>=2025.1",
     "PyYAML>=6.0.2,<7.0",
@@ -43,6 +43,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+video = [
+    "inorbit-edge[video]>=2.1,<3.0",
+]
 dev = [
     "bump2version~=1.0",
     "black~=25.9",


### PR DESCRIPTION
## Summary

`inorbit-edge[video,telemetry]` is currently a base dependency, which forces every consumer of `inorbit-connector` to install `opencv-python-headless` — even when their connector has no cameras. That package ships only manylinux wheels (no musllinux), so installing on Alpine Linux falls back to a source build that needs `cmake`, `ninja`, and a C toolchain. For camera-less connectors (fleet-API bridges, MQTT bridges, REST passthrough services) this is pure dead weight that breaks Alpine-based images.

This PR splits `[video]` out of the base requirements into a new `[video]` extra on `inorbit-connector` itself.

## Changes

- `pyproject.toml`: drop `[video]` from base `inorbit-edge` extras, add new optional `video = [\"inorbit-edge[video]>=2.1,<3.0\"]`.
- `docs/contents/publishing.md`: document the install-time opt-in (`pip install inorbit-connector[video]`).

## Why this is safe

- `inorbit_edge.video` already wraps the `cv2` import in `try/except` — only a benign warning is logged when cv2 is missing.
- `OpenCVCamera`'s class body references `cv2` only inside instance methods; the class itself imports cleanly without cv2.
- `connector.py:36` does `from inorbit_edge.video import OpenCVCamera` at module load — this succeeds with or without cv2 installed.
- The actual cv2 calls only happen if a `RobotConfig.cameras` entry is set, in which case `connector.py:419` instantiates `OpenCVCamera` and the user expects to need cv2 anyway.

## Verification

Verified locally on a fresh venv:

```
pip install .                    # → inorbit-connector + inorbit-edge, no opencv
pip install '.[video]'           # → opencv-python-headless 4.13.0.92 added
```

Full framework test suite (170 tests) passes with cv2 uninstalled — confirming no test or framework code path takes a hard cv2 dependency.

## Migration for existing connectors

- Connectors with cameras: change `inorbit-connector` → `inorbit-connector[video]` in their requirements.
- Connectors without cameras: no change needed — they get a leaner dependency tree automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)