### PR TITLE
metrics: per-connector_type namespace by default; CUMULATIVE end to end

### DIFF
--- a/docs/contents/usage/metrics.md
+++ b/docs/contents/usage/metrics.md
@@ -9,40 +9,51 @@ The framework ships an OpenTelemetry-based metrics subsystem that connectors can
 
 When `metrics.enabled = true` in your connector configuration, the framework starts a Prometheus HTTP server and exposes:
 
+Every framework metric is namespaced by `connector_type` at the source.
+With `connector_type="acme"` (set on `ConnectorConfig`), the four
+framework signals come out as:
+
 | Metric | Type | Attributes | Meaning |
 |---|---|---|---|
-| `inorbit_connector_up` | Gauge | — | 1 while the connector's main thread is alive |
-| `inorbit_connector_session_connected` | Gauge | `robot_id` | 1 when the per-robot MQTT session to InOrbit is connected. Catches the "process running but robot offline" failure mode where MQTT drops and reconnect fails |
-| `inorbit_connector_execution_loop_ticks_total` | Counter | — | Successful iterations of `_execution_loop` |
-| `inorbit_connector_execution_loop_errors_total` | Counter | — | Exceptions caught in the run loop |
+| `inorbit_acme_connector_up` | Gauge | — | 1 while the connector's main thread is alive |
+| `inorbit_acme_connector_session_connected` | Gauge | `robot_id` | 1 when the per-robot MQTT session to InOrbit is connected. Catches the "process running but robot offline" failure mode where MQTT drops and reconnect fails |
+| `inorbit_acme_connector_execution_loop_ticks_total` | Counter | — | Successful iterations of `_execution_loop` |
+| `inorbit_acme_connector_execution_loop_errors_total` | Counter | — | Exceptions caught in the run loop |
 
-Plus the per-robot publish counters that come from the SDK:
+Plus the per-robot publish counters that come from the SDK (same
+namespacing):
 
 | Metric | Attributes | Meaning |
 |---|---|---|
-| `calls_publish_pose_total` | `robot_id` | Calls to `publish_pose` |
-| `calls_publish_odometry_total` | `robot_id` | Calls to `publish_odometry` |
-| `calls_publish_key_values_total` | `robot_id` | Calls to `publish_key_values` |
-| `calls_publish_system_stats_total` | `robot_id` | Calls to `publish_system_stats` |
-| `calls_publish_map_total` | `robot_id` | Calls to `publish_map` |
-| `calls_publish_camera_frame_total` | `robot_id` | Calls to `publish_camera_frame` |
-| `calls_publish_lasers_total` | `robot_id` | Calls to `publish_lasers` / `publish_laser` |
-| `calls_publish_path_total` | `robot_id` | Calls to `publish_path` |
+| `inorbit_acme_connector_calls_publish_pose_total` | `robot_id` | Calls to `publish_pose` |
+| `inorbit_acme_connector_calls_publish_odometry_total` | `robot_id` | Calls to `publish_odometry` |
+| `inorbit_acme_connector_calls_publish_key_values_total` | `robot_id` | Calls to `publish_key_values` |
+| `inorbit_acme_connector_calls_publish_system_stats_total` | `robot_id` | Calls to `publish_system_stats` |
+| `inorbit_acme_connector_calls_publish_map_total` | `robot_id` | Calls to `publish_map` |
+| `inorbit_acme_connector_calls_publish_camera_frame_total` | `robot_id` | Calls to `publish_camera_frame` |
+| `inorbit_acme_connector_calls_publish_lasers_total` | `robot_id` | Calls to `publish_lasers` / `publish_laser` |
+| `inorbit_acme_connector_calls_publish_path_total` | `robot_id` | Calls to `publish_path` |
+
+The per-connector-type prefix means descriptors in any downstream metric
+store are isolated by connector type — two connectors built on this
+framework never collide. To query across connector types, use a wildcard
+(`inorbit_*_connector_*`) and rely on the `connector_type` label
+attached automatically.
 
 These signals are usually enough for an MVP alerting setup:
 
 ```promql
-# Process is dead or scrape failing
-inorbit_connector_up == 0
+# Process is dead or scrape failing — across every connector type
+inorbit_.*_connector_up == 0
 
 # Process is up but its MQTT link to InOrbit is down (robot appears offline)
-inorbit_connector_session_connected == 0
+inorbit_.*_connector_session_connected == 0
 
 # Process is up but not progressing
-rate(inorbit_connector_execution_loop_ticks_total[5m]) == 0
+rate(inorbit_acme_connector_execution_loop_ticks_total[5m]) == 0
 
 # Process is up but erroring
-rate(inorbit_connector_execution_loop_errors_total[5m]) > 0
+rate(inorbit_acme_connector_execution_loop_errors_total[5m]) > 0
 ```
 
 ## Enabling metrics
@@ -74,7 +85,7 @@ When `enabled` is `false` (the default), no server is started and all instrument
 | `advertise_host` | `socket.gethostname()` | Hostname written to the discovery file. |
 | `discovery_dir` | `/var/run/inorbit-metrics` | Auto-created on start. Set to `null` to skip writing a discovery file. |
 | `connector_id` | `socket.gethostname()` | Used as `service.instance.id` and as the discovery filename. |
-| `exporter_namespace` | `"inorbit_connector"` | Prefix prepended to every Prometheus metric name. ASCII / no hyphens. |
+| `exporter_namespace` | `None` (auto: `inorbit_<connector_type>_connector`) | Prefix prepended to every Prometheus metric name. ASCII / no hyphens. Set explicitly only to override the auto-derived value. |
 | `extra_resource_attributes` | `{}` | Added to every metric as OTEL Resource attributes (low-cardinality only). |
 
 ## Adding metrics to your connector
@@ -90,14 +101,23 @@ from inorbit_edge.metrics import get_meter
 meter = get_meter("inorbit_my_connector")
 
 api_requests = meter.create_counter(
-    "my.api.requests", unit="1", description="Calls to the device API",
+    "api.requests", unit="1", description="Calls to the device API",
 )
 api_errors = meter.create_counter(
-    "my.api.errors", unit="1", description="Failed calls to the device API",
+    "api.errors", unit="1", description="Failed calls to the device API",
 )
 ```
 
 The same module-level pattern the SDK uses for its own counters. `get_meter` returns a real OTEL `Meter` when telemetry deps are installed (always the case via `inorbit-edge[telemetry]`), or a no-op `Meter` otherwise.
+
+#### Naming rule: don't repeat the namespace in instrument names
+
+`exporter_namespace` is prepended to every metric on export — for a connector with `connector_type="acme"`, the framework derives `inorbit_acme_connector`, so `api.requests` above surfaces as `inorbit_acme_connector_api_requests_total` on `/metrics`. Don't add the namespace to the instrument name yourself — the meter name is decorative (it surfaces only as `instrumentation_scope`); the instrument name is the metric.
+
+- ✅ `meter.create_counter("api.requests", ...)` → `inorbit_acme_connector_api_requests_total`
+- ❌ `meter.create_counter("inorbit.acme.connector.api.requests", ...)` → `inorbit_acme_connector_inorbit_acme_connector_api_requests_total`
+
+A double-prefixed wire name can only be cleaned up by a collector-side `metric_relabel_configs` rule that rewrites `__name__`. Those rewrites strip the Prometheus `# TYPE` line, so the metric arrives at the OTEL pipeline as `UNKNOWN` and is exported as a Gauge regardless of its real type. Downstream metric stores that pin descriptor kind on first write (GCP Cloud Monitoring, for example) then silently drop later writes of the correct type.
 
 ### Step 2 — Instrument calls
 

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -14,6 +14,76 @@ hostnames, exporters, and credential mounts will all need to be adjusted for
 your environment. For the supported `metrics:` configuration fields, see the
 [Metrics user guide](../../docs/contents/usage/metrics.md).
 
+## Design rules
+
+The example config in this directory encodes two rules that keep metrics
+flowing into a managed metric backend (GCP Cloud Monitoring in
+particular). Each addresses a failure mode that produces sparse data
+with no clear error in the collector log.
+
+> **Note on descriptor isolation.** A separate "one `metric.prefix` per
+> connector type" rule used to live here. The framework now derives a
+> per-connector-type prefix at the source
+> (`inorbit_<connector_type>_connector_*`), so two connectors built on
+> this framework can never share a downstream metric descriptor and the
+> operator no longer picks a prefix per vendor. `connector_type` is also
+> surfaced as a series-key label so cross-vendor queries work without
+> inspecting metric names.
+
+### Rule 1 — Don't rewrite `__name__` in `metric_relabel_configs`
+
+The Prometheus receiver warns at startup that any rule writing
+`__name__` produces "unknown-typed metrics without a unit or
+description". The renamed metric loses its Counter/Histogram type and
+exports as a Gauge regardless of its real type — and that then pins the
+downstream descriptor kind to `GAUGE`, which later writes of the
+correct kind cannot recover from.
+
+Fix metric names at the source (see [Metrics user
+guide](../../docs/contents/usage/metrics.md)). Drop-only relabel rules
+(no `target_label: __name__`) are safe — they filter before any naming
+step.
+
+### Rule 2 — Preserve per-series write ordering
+
+GCP rejects `CUMULATIVE` and `DELTA` writes whose `interval.start_time`
+precedes the last accepted `end_time` for the same series. Dropped
+points produce no error log entry, only gaps on the chart. This
+pipeline keeps cumulative counters as CUMULATIVE end to end and relies
+on three invariants to keep writes monotonic:
+
+- **One writer per series.** The framework's per-`connector_type`
+  namespace guarantees this for framework-emitted metrics — a series
+  is keyed by metric name + labels, and the metric name is now
+  vendor-prefixed. If you add custom resource attributes that bridge
+  connector types, keep ownership inside one connector type.
+- **Serial sends.** `sending_queue.num_consumers: 1` makes the
+  exporter's queue strictly FIFO. A retry blocks the queue rather
+  than racing the next batch.
+- **Single collector per fleet.** Two collector replicas scraping the
+  same connector and writing to the same project would race; deploy
+  one collector instance per metric-namespace scope.
+
+CUMULATIVE has a self-healing property under transient failures: if a
+batch is dropped permanently (queue eviction during a long outage,
+exhausted retries), the next successful write still carries the full
+running total, so the series's reconstruction stays correct from that
+point on.
+
+Connector restarts are handled natively. The Prometheus receiver
+detects the counter reset (value decrease), advances the series's
+`start_time`, and GCP recognizes it as a new cumulative epoch.
+`ALIGN_RATE` charts and `rate(...)`-based alerts cross the restart
+boundary without artifacts.
+
+### Switching to a different metric backend
+
+If you swap `googlecloud` for Cortex/Mimir/Prometheus remote_write,
+`num_consumers: 1` can be relaxed — those backends accept out-of-order
+writes for cumulative counters and reconcile on the server side. Rule
+1 still applies to any backend that consumes Prometheus type
+information.
+
 ## How it works
 
 1. Each connector container runs a Prometheus-format HTTP endpoint bound to a
@@ -98,7 +168,8 @@ For the connector configuration reference and metric catalog, see the
   Look for `Scrape iteration` entries referring to your connector targets.
 
 - In GCP Cloud Monitoring, under Custom Metrics, look for
-  `custom.googleapis.com/inorbit_connector/*` series.
+  `workload.googleapis.com/<vendor>_connector/*` series (using whichever
+  `metric.prefix` you set in the exporter — see Rule 1 above).
 
 ## Host-networking alternative
 

--- a/examples/metrics/otel-collector-config.yaml
+++ b/examples/metrics/otel-collector-config.yaml
@@ -1,35 +1,116 @@
 # SPDX-FileCopyrightText: 2026 InOrbit, Inc.
 # SPDX-License-Identifier: MIT
+#
+# Reference OTEL collector config for inorbit-connector fleets exporting to
+# GCP Cloud Monitoring. See README.md in this directory for the rules each
+# block encodes; do not loosen them without reading that file first.
 
 receivers:
   prometheus:
     config:
+      global:
+        scrape_interval: 30s
+        scrape_timeout: 10s
       scrape_configs:
-        - job_name: inorbit-connectors
-          scrape_interval: 30s
+        - job_name: inorbit_connectors
+          # Preserve target_info series labels so connector-side resource
+          # attributes (notably inorbit_connector_id) surface as OTEL
+          # resource attributes for the `resource` processor below.
+          honor_labels: true
+          metrics_path: /metrics
           file_sd_configs:
-            - files: [/var/run/inorbit-metrics/*.json]
+            - files: ['/var/run/inorbit-metrics/*.json']
               refresh_interval: 30s
+          # Drop-only relabels are safe. Do NOT add a rule that writes
+          # `__name__` — see Rule 1 in README.md.
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'python_.*|process_.*'
+              action: drop
 
 processors:
+  # Bound RSS so backpressure from the metric backend can't balloon it.
+  memory_limiter:
+    check_interval: 2s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  # Pin the generic_task Monitored Resource fields. The googlecloud
+  # exporter's MR mapping is hardcoded to these standard OTel attributes:
+  #   generic_task.namespace <- service.namespace
+  #   generic_task.job       <- service.name
+  #   generic_task.location  <- cloud.availability_zone | cloud.region
+  #   generic_task.task_id   <- service.instance.id
+  resource:
+    attributes:
+      - {key: service.namespace,   value: inorbit_connector_fleet, action: upsert}
+      - {key: service.name,        value: inorbit_connector,       action: upsert}
+      - {key: cloud.region,        value: us-central1,             action: upsert}
+      - {key: service.instance.id, from_attribute: inorbit_connector_id,   action: upsert}
+      # Promote the connector_type tag the framework already attaches as
+      # a metric label so cross-connector dashboards can group / filter
+      # by it without inspecting metric names.
+      - {key: connector_type,      from_attribute: inorbit_connector_type, action: upsert}
+      # Per-customer label. Any other resource attribute you want as a
+      # series-key must be added here AND matched under resource_filters.
+      - {key: customer, value: CHANGEME, action: upsert}
+
   batch:
-    send_batch_size: 1024
+    send_batch_size: 200
+    send_batch_max_size: 500
     timeout: 10s
 
 exporters:
   googlecloud:
-    project: ${env:GCP_PROJECT}
+    project: ${env:GOOGLE_CLOUD_PROJECT}
     metric:
-      prefix: custom.googleapis.com/inorbit_connector
+      # One shared prefix for every connector type. Descriptor isolation
+      # is guaranteed by the per-connector_type metric NAME prefix that
+      # the framework derives at the source (inorbit_<type>_connector_*),
+      # so the operator no longer picks a prefix per vendor.
+      prefix: workload.googleapis.com/
+      # connector_type is exported as a series-key label too, so a single
+      # query can slice across connector types ("all robots offline for
+      # customer=acme") AND drill into one ("MIR fleet only").
       resource_filters:
-        - prefix: ""
+        - regex: ^customer$
+        - regex: ^connector_type$
+    # Default 12s is too aggressive given hourly OAuth-refresh reconnect
+    # windows; dials get canceled mid-handshake at 12s.
+    timeout: 30s
+    sending_queue:
+      enabled: true
+      # Serial sends — see Rule 2 in README.md. CUMULATIVE writes must
+      # arrive monotonically per series; parallel consumers can deliver
+      # older batches after newer ones during retry storms and trip the
+      # per-series ordering rejection. Serial sending makes the queue
+      # strictly FIFO, so retries block the next batch rather than
+      # racing it.
+      num_consumers: 1
+      # Absorbs backpressure (OAuth refresh, NAT reconnect) without the
+      # prometheus receiver dropping at enqueue time. CUMULATIVE writes
+      # are self-healing across drops — the next successful write
+      # carries the full running total — but we still want headroom.
+      queue_size: 10000
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
 
 service:
-  pipelines:
-    metrics:
-      receivers: [prometheus]
-      processors: [batch]
-      exporters: [googlecloud]
+  extensions: [health_check]
   telemetry:
     logs:
       level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [memory_limiter, resource, batch]
+      exporters: [googlecloud]

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -32,8 +32,14 @@ except ImportError:
 
 # Third Party
 from inorbit_edge.models import RobotSessionModel
-from inorbit_edge.robot import RobotSession, RobotSessionPool, RobotSessionFactory
+from inorbit_edge.robot import (
+    INORBIT_REST_API_URL,
+    RobotSession,
+    RobotSessionPool,
+    RobotSessionFactory,
+)
 from inorbit_edge.video import OpenCVCamera
+from pydantic import HttpUrl
 
 # Optional dependency for connector system stats
 try:
@@ -174,9 +180,17 @@ class FleetConnector(ABC):
         # automatically loaded environment variables Robot-specific values (robot_id,
         # robot_name) have to be ommited after initalization before passing the config
         # to the factory.
+        # `rest_api_endpoint` is set explicitly: the SDK's default is a
+        # raw string into a `HttpUrl` field, which trips Pydantic's
+        # serializer warning on every `model_dump()` below. Constructing
+        # a `HttpUrl` here is a no-op for the runtime value but produces
+        # a typed default that serializes cleanly.
         robot_session_config = RobotSessionModel(
             api_key=config.api_key,
             endpoint=config.api_url,
+            rest_api_endpoint=HttpUrl(
+                os.environ.get("INORBIT_REST_API_URL", INORBIT_REST_API_URL)
+            ),
             account_id=config.account_id,
             robot_key=config.inorbit_robot_key,
             robot_id="required_value",

--- a/inorbit_connector/metrics/__init__.py
+++ b/inorbit_connector/metrics/__init__.py
@@ -9,16 +9,27 @@ connector health and provides one entry point — :func:`setup_prometheus_metric
 
 Framework instruments (always declared, no-op when metrics are disabled):
 
-* ``inorbit.connector.up`` — 1 while the connector's main thread is alive
-* ``inorbit.connector.session.connected`` — per-robot MQTT connection status (1/0)
-* ``inorbit.connector.execution_loop.ticks`` — successful run-loop iterations
-* ``inorbit.connector.execution_loop.errors`` — exceptions caught in the loop
+* ``up`` — 1 while the connector's main thread is alive
+* ``session.connected`` — per-robot MQTT connection status (1/0)
+* ``execution_loop.ticks`` — successful run-loop iterations
+* ``execution_loop.errors`` — exceptions caught in the loop
+
+The Prometheus reader prepends ``exporter_namespace`` to every metric on
+export. When ``MetricsConfig.exporter_namespace`` is left unset (the
+default), :func:`setup_prometheus_metrics` derives it as
+``inorbit_<connector_type>_connector``, so a connector with
+``connector_type="acme"`` exports ``inorbit_acme_connector_up``,
+``inorbit_acme_connector_execution_loop_ticks_total`` etc. Two connector
+types therefore never share a metric name and never collide on a
+downstream metric descriptor. Instrument names must not repeat the
+namespace — the prefix is added once on export, never in the name.
 
 For domain metrics (e.g. ``fleet.api.errors``, ``mqtt.broker.connected``),
 concrete connectors get their own meter via
 ``inorbit_edge.metrics.get_meter("inorbit_<vendor>_connector")`` and declare
-instruments on it. They share the global MeterProvider installed here, so
-everything flows through the same Prometheus endpoint.
+instruments on it under the same convention. They share the global
+MeterProvider installed here, so everything flows through the same
+Prometheus endpoint.
 
 The Prometheus exporter ships transitively via ``inorbit-edge[telemetry]``,
 which is a base dependency of this package, so OTEL is always importable.
@@ -62,12 +73,26 @@ def setup_prometheus_metrics(
     that maps :class:`MetricsConfig` to the SDK call. Returns True when a
     provider was installed; False when metrics are disabled or the telemetry
     dependencies are missing.
+
+    The wire-level metric prefix is derived per connector_type when
+    ``config.exporter_namespace`` is unset (the default). That gives every
+    connector type a unique namespace
+    (``inorbit_<connector_type>_connector``) so two connector types
+    sharing a downstream metric store don't collide on the same metric
+    descriptor — each owns its own. Pass ``exporter_namespace`` explicitly
+    only to opt out of the derivation (e.g. to keep a legacy wire name).
     """
     if not config.enabled:
         return False
 
+    namespace = (
+        config.exporter_namespace
+        if config.exporter_namespace is not None
+        else f"inorbit_{connector_type}_connector"
+    )
+
     installed = setup_prometheus_meter_provider(
-        service_name=config.exporter_namespace,
+        service_name=namespace,
         service_instance_id=connector_id,
         service_version=_connector_version,
         extra_resource_attributes={
@@ -206,12 +231,12 @@ class MetricsServer:
 meter = get_meter("inorbit_connector")
 
 execution_loop_ticks = meter.create_counter(
-    "inorbit.connector.execution_loop.ticks",
+    "execution_loop.ticks",
     unit="1",
     description="Successful iterations of the connector's _execution_loop",
 )
 execution_loop_errors = meter.create_counter(
-    "inorbit.connector.execution_loop.errors",
+    "execution_loop.errors",
     unit="1",
     description="Exceptions caught in the run loop",
 )
@@ -229,14 +254,14 @@ def register_framework_gauges(
 
     Args:
         is_alive: zero-arg callable returning whether the connector's main
-            thread is alive. Drives ``inorbit.connector.up``.
+            thread is alive. Drives ``up``.
         robot_ids: zero-arg callable returning the current list of robot ids
             in the fleet.
         is_session_connected: callable ``(robot_id: str) -> bool`` that
             returns whether the underlying MQTT session for that robot is
-            currently connected. Drives
-            ``inorbit.connector.session.connected``. Should swallow lookup
-            errors and return False when the session is not yet available.
+            currently connected. Drives ``session.connected``. Should
+            swallow lookup errors and return False when the session is not
+            yet available.
     """
     if not OTEL_API_AVAILABLE:
         return
@@ -254,13 +279,13 @@ def register_framework_gauges(
         ]
 
     meter.create_observable_gauge(
-        "inorbit.connector.up",
+        "up",
         callbacks=[_up_callback],
         unit="1",
         description="1 while the connector main thread is alive",
     )
     meter.create_observable_gauge(
-        "inorbit.connector.session.connected",
+        "session.connected",
         callbacks=[_session_callback],
         unit="1",
         description=(

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -156,12 +156,14 @@ class MetricsConfig(BaseModel):
     advertise_host: Optional[str] = None
     discovery_dir: Optional[Path] = Path("/var/run/inorbit-metrics")
     connector_id: Optional[str] = None
-    exporter_namespace: str = "inorbit_connector"
+    exporter_namespace: Optional[str] = None
     extra_resource_attributes: dict[str, str] = {}
 
     @field_validator("exporter_namespace")
     @classmethod
-    def _validate_exporter_namespace(cls, value: str) -> str:
+    def _validate_exporter_namespace(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
         if not _METRICS_IDENTIFIER_RE.fullmatch(value):
             raise ValueError(
                 "exporter_namespace must match [A-Za-z_][A-Za-z0-9_]* "

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -246,7 +246,15 @@ class ConnectorConfig(BaseModel):
     """
 
     api_key: str | None = os.getenv("INORBIT_API_KEY")
-    api_url: HttpUrl = os.getenv("INORBIT_API_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
+    # default_factory + explicit HttpUrl construction: handing a bare
+    # string default to a `HttpUrl`-typed field stores it as `str` (the
+    # type-coercion validator only runs on explicit inputs, not defaults),
+    # which then trips Pydantic's serializer warning on every model_dump.
+    api_url: HttpUrl = Field(
+        default_factory=lambda: HttpUrl(
+            os.getenv("INORBIT_API_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
+        )
+    )
     connector_type: str
     connector_config: BaseModel
     use_websockets: bool = False

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -275,7 +275,7 @@ class TestFleetConnector:
         mock_loop.is_running.return_value = True
         base_fleet_connector._FleetConnector__loop = mock_loop
 
-        with patch("asyncio.run_coroutine_threadsafe"):
+        with patch("asyncio.run_coroutine_threadsafe") as mock_run:
             base_fleet_connector.publish_robot_pose(
                 robot_id, 1.0, 2.0, 0.0, "unknown_frame"
             )
@@ -288,6 +288,10 @@ class TestFleetConnector:
         session.publish_map.assert_not_called()
         # publish_pose called both times
         assert session.publish_pose.call_count == 2
+        # mock_run never scheduled the coroutine(s) — close them so GC
+        # doesn't surface "coroutine was never awaited" later.
+        for call in mock_run.call_args_list:
+            call[0][0].close()
 
     def test_publish_robot_odometry(
         self, base_fleet_connector, mock_robot_session_pool
@@ -423,6 +427,10 @@ class TestFleetConnectorMapFetching:
             assert "unknown_frame" in (
                 fleet_connector._FleetConnector__pending_map_fetches
             )
+            # mock_run swallowed the coroutine without scheduling it on a
+            # real loop; close it so the GC doesn't surface an
+            # "coroutine was never awaited" warning later.
+            mock_run.call_args[0][0].close()
 
     def test_schedule_map_fetch_avoids_duplicates(
         self, fleet_connector, mock_robot_session_pool
@@ -441,6 +449,9 @@ class TestFleetConnectorMapFetching:
             # Second request for same frame should be ignored
             fleet_connector._schedule_map_fetch("TestRobot1", "frame1", False)
             assert mock_run.call_count == 1  # Still 1, not 2
+
+            # mock_run never scheduled the coroutine; close it explicitly.
+            mock_run.call_args_list[0][0][0].close()
 
     def test_schedule_map_fetch_requires_running_loop(
         self, fleet_connector, mock_robot_session_pool

--- a/tests/test_connector_metrics.py
+++ b/tests/test_connector_metrics.py
@@ -91,7 +91,8 @@ def test_metrics_server_lifecycle(tmp_path, patched_run_connector):
         ) as resp:
             body = resp.read().decode()
         assert resp.status == 200
-        assert "inorbit_connector_up" in body
+        # connector_type="test" → derived namespace `inorbit_test_connector_*`.
+        assert "inorbit_test_connector_up" in body
     finally:
         conn.stop()
 

--- a/tests/test_metrics_setup.py
+++ b/tests/test_metrics_setup.py
@@ -58,3 +58,15 @@ def test_enabled_installs_provider_with_identity_attributes():
     assert attrs["inorbit.connector.id"] == "rId-1"
     assert attrs["site"] == "lab"
     assert "service.version" in attrs
+
+
+def test_enabled_derives_namespace_from_connector_type_when_unset():
+    cfg = MetricsConfig(enabled=True)  # exporter_namespace left at None
+    assert setup_prometheus_metrics(cfg, "acme", "rId-1") is True
+
+    provider = otel_metrics.get_meter_provider()
+    attrs = dict(provider._sdk_config.resource.attributes)
+    # service.name is the wire-level prefix; the prom exporter prepends
+    # it to every metric. With connector_type="acme" the derived value
+    # gives `inorbit_acme_connector_*` on the wire.
+    assert attrs["service.name"] == "inorbit_acme_connector"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -624,7 +624,7 @@ class TestMetricsConfig:
         assert cfg.advertise_host is None
         assert cfg.discovery_dir == Path("/var/run/inorbit-metrics")
         assert cfg.connector_id is None
-        assert cfg.exporter_namespace == "inorbit_connector"
+        assert cfg.exporter_namespace is None
         assert cfg.extra_resource_attributes == {}
 
     def test_exporter_namespace_rejects_hyphens(self):
@@ -638,6 +638,12 @@ class TestMetricsConfig:
     def test_exporter_namespace_accepts_underscores_and_digits(self):
         cfg = MetricsConfig(exporter_namespace="inorbit_connector_v2")
         assert cfg.exporter_namespace == "inorbit_connector_v2"
+
+    def test_exporter_namespace_accepts_none_for_auto_derive(self):
+        # None means setup_prometheus_metrics derives
+        # `inorbit_<connector_type>_connector` at install time.
+        cfg = MetricsConfig(exporter_namespace=None)
+        assert cfg.exporter_namespace is None
 
     def test_extra_resource_attributes_rejects_empty_values(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary

- `MetricsConfig.exporter_namespace` defaults to `None`. When unset, `setup_prometheus_metrics` derives `inorbit_<connector_type>_connector` at install time, so every connector type ships a distinct wire-level prefix on every metric (`inorbit_connectorA_connector_up`, `inorbit_connectorB_connector_up`, …). Two connector types built on this framework can no longer collide on a downstream metric descriptor.
- The four framework instruments (`up`, `session.connected`, `execution_loop.ticks`, `execution_loop.errors`) drop the redundant `inorbit.connector.` source-side prefix; the namespace is added once on export.
- Rewrites `examples/metrics/otel-collector-config.yaml` to preserve CUMULATIVE temporality end to end. The pipeline relies on per-series ordering invariants (serial sends, one writer per series, one collector per fleet) to keep writes monotonic.
- Promotes the framework's existing `inorbit.connector.type` resource attribute to a series-key metric label (`connector_type`) so cross-vendor queries are one filter, not one query per connector type.

## Why

The framework's `PrometheusMetricReader` prepends `exporter_namespace` to every metric on export. Before this change, every connector type shared the prefix `inorbit_connector` (so every connector emitted `inorbit_connector_up`, `inorbit_connector_calls_publish_pose_total`, …). Downstream metric stores that pin descriptor kind on first write (GCP Cloud Monitoring among them) then locked every shared metric to whichever kind the first-booting connector type happened to emit. The other connector type's writes were silently dropped on kind mismatch with no error log.

Deriving the namespace per `connector_type` at the framework level moves descriptor isolation out of the operator's hands and into the framework. The operator now runs one shared collector config for every connector type on the host.

The four framework instrument names also needed the same rename: their old names included `inorbit.connector.` at the source, which then double-prefixed against the namespace on the wire (`inorbit_<type>_connector_inorbit_connector_*`). The only collector-side fix for a double-prefixed wire name is a `metric_relabel_configs` rule rewriting `__name__`, which strips the Prometheus `# TYPE` line and exports the metric as `UNKNOWN`/Gauge regardless of its real type — which then pins the downstream descriptor kind to `GAUGE`. Renaming at the source removes the only reason to need a `__name__` rewrite in the collector at all.

## Pipeline shape

```
prometheus receiver → memory_limiter → resource → batch → googlecloud
                                      (sets MR fields, surfaces connector_type)
```

The transform that used to convert Sums to Gauges is gone. CUMULATIVE counters arrive at GCP as `CUMULATIVE` metric descriptors, so charts and alerts see correct kinds and `ALIGN_RATE` handles connector restarts natively (GCP recognizes the `start_time` advance on counter reset, without negative-rate artifacts).

## Rules captured in the example collector config

1. **No `__name__` rewrites in `metric_relabel_configs`.** Drop-only relabels (kept for filtering `python_*` / `process_*` from the default `prometheus_client` registry) are safe.
2. **Per-series write ordering.** GCP rejects `CUMULATIVE`/`DELTA` writes whose `start_time` precedes the last accepted `end_time` for the same series. Three invariants preserve monotonicity:
   - One writer per series — guaranteed for framework metrics by the per-`connector_type` namespace.
   - `sending_queue.num_consumers: 1` — strictly FIFO; retries block the queue rather than racing the next batch.
   - One collector instance per metric-namespace scope.

Plus `timeout: 30s` on the exporter for OAuth-refresh tolerance. The earlier "per-vendor `metric.prefix`" rule is gone — the framework now enforces descriptor isolation at the source.

## Other connectors

None of the existing connectors need code changes. They already pass `connector_type` to `ConnectorConfig`, which is all the framework needs to derive the namespace. The migration is:

1. Bump `inorbit-connector` to this release in each connector's `pyproject.toml`.
2. Deploy the new example collector config (or merge the additions into existing ones — `resource` processor adds the `connector_type` attribute and `resource_filters` adds the matching regex).
3. One-time: delete stale `workload.googleapis.com/inorbit_connector/*` metric descriptors so the new `inorbit_<type>_connector_*` series create cleanly as `CUMULATIVE`.
4. One-time: update dashboards/alerts that referenced `inorbit_connector_*` to use either the explicit `inorbit_<type>_connector_*` per fleet or the wildcard `inorbit_*_connector_*` for cross-fleet views.

A connector that wants to preserve the old wire names can pass `exporter_namespace="inorbit_connector"` in its `MetricsConfig` explicitly.

## Compatibility

Breaking change for the metric NAMES on `/metrics` and in downstream stores (`inorbit_connector_*` → `inorbit_<connector_type>_connector_*`). The fix is small and one-time. Operators who can't migrate dashboards in lockstep can opt out by setting `exporter_namespace` explicitly.

## Test plan

- [x] `tests/test_metrics_*.py` and `tests/test_models.py::TestMetricsConfig` pass on this branch (16 tests, full).
- [x] Full suite: 115 passing; 1 pre-existing cross-test isolation flake (`test_metrics_server_lifecycle`) that also exists on `main`.
- [x] End-to-end smoke (manual): scraping `/metrics` with `connector_type="acme"` shows `inorbit_acme_connector_up`, `inorbit_acme_connector_session_connected{robot_id=...}`, `inorbit_acme_connector_execution_loop_ticks_total` with correct Prometheus `# TYPE` lines.
- [x] Deploy the new example collector config against a staging GCP project; confirm `workload.googleapis.com/inorbit_<type>_connector_*` descriptors are created with the expected `metricKind` (`CUMULATIVE` for counters, `GAUGE` for `up` / `session_connected`, `CUMULATIVE`/`DISTRIBUTION` for histograms) and accept writes continuously across multiple connector types under the shared `metric.prefix`.
- [x] Verify `ALIGN_RATE` charts for `inorbit_<type>_connector_execution_loop_ticks_total` are continuous across a connector restart (no negative-rate spike).
- [x] Verify a single Metrics Explorer query filtered by `metric.label.customer="acme"` covers every connector type on the host.