### PR TITLE
Remove deprecated Connector._robot_session property

### DIFF
--- a/docs/contents/specification/connector.md
+++ b/docs/contents/specification/connector.md
@@ -196,8 +196,4 @@ Single-robot convenience for online status. The fleet-level online check delegat
 
 Returns the underlying Edge SDK session for the current robot.
 
-### Deprecated: `_robot_session`
-
-`Connector._robot_session` is deprecated; use `_get_session()` instead.
-
 

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -24,12 +24,6 @@ try:
 except ImportError:
     from typing_extensions import override
 
-# Python 3.13+ compatibility for deprecated decorator
-try:
-    from warnings import deprecated
-except ImportError:
-    from typing_extensions import deprecated
-
 # Third Party
 from inorbit_edge.models import RobotSessionModel
 from inorbit_edge.robot import (
@@ -966,11 +960,6 @@ class Connector(FleetConnector, ABC):
         cases accessing the robot session directly may be necessary.
         """
         return super()._get_robot_session(self.robot_id)
-
-    @property
-    @deprecated("Use self._get_session() instead")
-    def _robot_session(self) -> RobotSession:
-        return self._get_session()
 
     def _is_robot_online(self) -> bool:
         """Check if the robot is online.


### PR DESCRIPTION
## Summary

- Remove the deprecated `Connector._robot_session` property and its `@deprecated` decorator from `connector.py`
- Remove the `deprecated` decorator import (Python 3.13+ compat block) — no longer used anywhere
- Remove the "Deprecated: `_robot_session`" section from the connector specification docs

## Breaking changes

`Connector._robot_session` property has been removed. It was deprecated in favor of `_get_session()`.

### Migration

```python
# Before (v2.x)
session = self._robot_session

# After (v3.0)
session = self._get_session()
```

`_get_session()` is unchanged and remains the canonical way to get the edge-sdk robot session for the current robot.