### PR TITLE
Remove command re-exports from inorbit_connector.connector

### DIFF
--- a/docs/contents/specification/commands.md
+++ b/docs/contents/specification/commands.md
@@ -44,15 +44,3 @@ These classes support type-safe parsing and validation of structured command par
 - `ExcludeUnsetMixin` changes `model_dump()` default behavior to `exclude_unset=True` (useful when you want to emit only explicitly-provided fields).
 
 See [Commands Handling](../usage/commands-handling) for end-to-end usage patterns.
-
-## Note: re-exports via `inorbit_connector.connector`
-
-For backwards compatibility, the connector module re-exports:
-
-- `CommandFailure`
-- `CommandResultCode`
-- `parse_custom_command_args`
-
-New code may import from either module, but the canonical definitions live in `inorbit_connector.commands`.
-
-

--- a/docs/contents/usage/commands-handling.md
+++ b/docs/contents/usage/commands-handling.md
@@ -72,7 +72,7 @@ The `CommandFailure` exception can be used to intentionally indicate a failure:
 Example usage:
 
 ```python
-from inorbit_connector.connector import CommandResultCode, CommandFailure
+from inorbit_connector.commands import CommandResultCode, CommandFailure
 
 @override
 async def _inorbit_robot_command_handler(
@@ -120,7 +120,7 @@ For details on how to configure actions with arguments, refer to the
 Use the helper `parse_custom_command_args()` to turn these into a script name and a parameters dictionary:
 
 ```python
-from inorbit_connector.connector import (
+from inorbit_connector.commands import (
     parse_custom_command_args,
     CommandResultCode,
     CommandFailure,
@@ -161,8 +161,12 @@ Optionally, you can combine `CommandModel` with `ExcludeUnsetMixin` to exclude u
 Define a command model by subclassing `CommandModel`:
 
 ```python
-from inorbit_connector.commands import CommandModel, parse_custom_command_args
-from inorbit_connector.connector import CommandResultCode, CommandFailure
+from inorbit_connector.commands import (
+    CommandModel,
+    parse_custom_command_args,
+    CommandResultCode,
+    CommandFailure,
+)
 
 class CommandQueueMission(CommandModel):
     """Command model for queue_mission command."""
@@ -297,8 +301,13 @@ The connector implements the command handler for the `schedule_mission` command 
 
 ```python
 from enum import StrEnum
-from inorbit_connector.commands import CommandModel, ExcludeUnsetMixin, parse_custom_command_args
-from inorbit_connector.connector import CommandResultCode
+from inorbit_connector.commands import (
+    CommandModel,
+    ExcludeUnsetMixin,
+    parse_custom_command_args,
+    CommandResultCode,
+    CommandFailure,
+)
 from inorbit_edge.commands import COMMAND_CUSTOM_COMMAND
 
 class CommandScheduleMission(ExcludeUnsetMixin, CommandModel):

--- a/docs/contents/usage/fleet.md
+++ b/docs/contents/usage/fleet.md
@@ -33,7 +33,7 @@ See the [Commands Handling](commands-handling) chapter for more details.
 Handle commands for a specific robot. This method is automatically registered if `register_custom_command_handler` is True (default).
 
 ```python
-from inorbit_connector.connector import CommandResultCode, CommandFailure
+from inorbit_connector.commands import CommandResultCode, CommandFailure
 
 @override
 async def _inorbit_robot_command_handler(

--- a/docs/contents/usage/single-robot.md
+++ b/docs/contents/usage/single-robot.md
@@ -83,7 +83,7 @@ See the [Commands Handling](commands-handling) chapter for more details.
 Handle commands received from InOrbit. This method is automatically registered if `register_custom_command_handler` is True (default).
 
 ```python
-from inorbit_connector.connector import CommandResultCode, CommandFailure
+from inorbit_connector.commands import CommandResultCode, CommandFailure
 
 @override
 async def _inorbit_command_handler(

--- a/examples/fleet-connector/connector.py
+++ b/examples/fleet-connector/connector.py
@@ -12,7 +12,8 @@ except ImportError:
     from typing_extensions import override
 
 # InOrbit
-from inorbit_connector.connector import CommandResultCode, FleetConnector
+from inorbit_connector.commands import CommandResultCode
+from inorbit_connector.connector import FleetConnector
 from inorbit_connector.models import MapConfigTemp
 
 # Local

--- a/examples/robot-connector/connector.py
+++ b/examples/robot-connector/connector.py
@@ -12,7 +12,8 @@ except ImportError:
     from typing_extensions import override
 
 # InOrbit
-from inorbit_connector.connector import CommandResultCode, Connector
+from inorbit_connector.commands import CommandResultCode
+from inorbit_connector.connector import Connector
 from inorbit_connector.models import MapConfigTemp
 
 # Local

--- a/examples/simple-connector/connector.py
+++ b/examples/simple-connector/connector.py
@@ -21,7 +21,8 @@ except ImportError:
 from pydantic import field_validator, BaseModel
 
 # InOrbit
-from inorbit_connector.connector import CommandResultCode, Connector
+from inorbit_connector.commands import CommandResultCode
+from inorbit_connector.connector import Connector
 from inorbit_connector.models import ConnectorConfig
 from inorbit_connector.utils import read_yaml
 

--- a/examples/simple-fleet-connector/connector.py
+++ b/examples/simple-fleet-connector/connector.py
@@ -21,7 +21,8 @@ except ImportError:
 from pydantic import field_validator, BaseModel
 
 # InOrbit
-from inorbit_connector.connector import CommandResultCode, FleetConnector
+from inorbit_connector.commands import CommandResultCode
+from inorbit_connector.connector import FleetConnector
 from inorbit_connector.models import ConnectorConfig
 from inorbit_connector.utils import read_yaml
 

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -51,12 +51,9 @@ except ImportError:
     PSUTIL_AVAILABLE = False
 
 # InOrbit
-from inorbit_connector.commands import (  # noqa: F401
-    # Re-export command-related functionality for backwards compatibility
-    # TODO: Remove in the next major release
+from inorbit_connector.commands import (
     CommandFailure,
     CommandResultCode,
-    parse_custom_command_args,
 )
 from inorbit_connector.logging.logger import setup_logger
 from inorbit_connector import metrics as _metrics

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,11 +15,6 @@ from inorbit_connector.commands import (
     ExcludeUnsetMixin,
     parse_custom_command_args,
 )
-from inorbit_connector.connector import (
-    CommandFailure as ConnectorCommandFailure,
-    parse_custom_command_args as connector_parse_custom_command_args,
-)
-
 
 # Test models for ExcludeUnsetMixin
 class ModelWithMixin(ExcludeUnsetMixin, BaseModel):
@@ -254,27 +249,6 @@ def test_parse_custom_command_args_protobuf_repeated_odd_length_raises():
 
     with pytest.raises(CommandFailure):
         parse_custom_command_args([msg.file_name, msg.arg_options])
-
-
-# ==============================================================================
-# Tests for backwards compatibility
-# TODO: Remove in the next major release
-# ==============================================================================
-
-
-def test_command_failure_importable_from_connector():
-    """Test that CommandFailure can still be imported from connector module."""
-    assert CommandFailure is ConnectorCommandFailure
-    failure = CommandFailure("test", "error")
-    assert isinstance(failure, ConnectorCommandFailure)
-
-
-def test_parse_custom_command_args_importable_from_connector():
-    """Test that parse_custom_command_args can still be imported from connector module."""
-    assert parse_custom_command_args is connector_parse_custom_command_args
-    script, params = parse_custom_command_args(["script.sh", ["x", "1.0"]])
-    assert script == "script.sh"
-    assert params == {"x": "1.0"}
 
 
 def test_command_model_works_with_parse_custom_command_args():


### PR DESCRIPTION
## Summary

- Remove the `# noqa: F401` re-export annotations and TODO comment from the
  commands import block in `connector.py`
- Remove `parse_custom_command_args` from the import (unused in `connector.py`);
  `CommandFailure` and `CommandResultCode` stay because they are used internally
- Remove two backward-compatibility tests and their import aliases from
  `test_commands.py`
- Remove the "Note: re-exports" section from `docs/contents/specification/commands.md`
- Update all code examples in usage docs (`commands-handling.md`, `fleet.md`,
  `single-robot.md`) to import from `inorbit_connector.commands`
- Update four example connectors to import `CommandResultCode` from
  `inorbit_connector.commands` instead of `inorbit_connector.connector`

## Breaking changes

`CommandFailure`, `CommandResultCode`, and `parse_custom_command_args` are no
longer guaranteed re-exports from `inorbit_connector.connector`. Import them
from `inorbit_connector.commands` instead.

### Migration

```python
# Before (v2.x)
from inorbit_connector.connector import (
    CommandResultCode,
    CommandFailure,
    parse_custom_command_args,
)

# After (v3.0)
from inorbit_connector.commands import (
    CommandResultCode,
    CommandFailure,
    parse_custom_command_args,
)
```