### PR TITLE
Migrate to `inorbit-edge` v3 and consolidate InOrbit environment variables

### DIFF
--- a/docs/contents/configuration.md
+++ b/docs/contents/configuration.md
@@ -25,7 +25,6 @@ Connectors parametrize `ConnectorRootConfig[T]` with a concrete `ConnectorSpecif
 - **`env_vars`** (dict[str, str]): Environment variables to be set in the connector or user scripts
 - **`fleet`** (list[RobotConfig]): List of robot configurations (see below)
 - **`user_scripts_dir`** (DirectoryPath | None): Path to directory containing user scripts for command execution
-- **`account_id`** (str | None): InOrbit account ID, required for publishing footprints
 - **`inorbit_robot_key`** (str | None): Robot key for InOrbit Connect robots. Required unless `api_key` is provided. See [API documentation](https://api.inorbit.ai/docs/index.html#operation/generateRobotKey)
 - **`metrics`** (MetricsConfig): Optional Prometheus metrics endpoint. Disabled by default. See [Metrics](usage/metrics) for the full guide and [`MetricsConfig`](#metricsconfig) for the field list.
 

--- a/docs/contents/configuration.md
+++ b/docs/contents/configuration.md
@@ -14,7 +14,8 @@ Connectors parametrize `ConnectorRootConfig[T]` with a concrete `ConnectorSpecif
 ### Key Fields
 
 - **`api_key`** (str | None): The InOrbit API key. Can be set via environment variable `INORBIT_API_KEY`. Required unless `inorbit_robot_key` is provided
-- **`api_url`** (HttpUrl): The URL of the InOrbit API endpoint. Defaults to InOrbit Cloud SDK URL. Can be set via environment variable `INORBIT_API_URL`
+- **`connection_config_url`** (HttpUrl): The URL of the connection config endpoint. Defaults to the InOrbit Cloud SDK URL. Can be set via the environment variable `INORBIT_CONNECTION_CONFIG_URL`
+- **`api_url`** (HttpUrl): The URL of the InOrbit REST API. Defaults to `https://api.inorbit.ai`. Can be set via the environment variable `INORBIT_API_URL`
 - **`connector_type`** (str): Defensive load-time check that the configuration in hand was authored for this connector. Its only valid value is the `CONNECTOR_TYPE` declared by the parametrized `connector_config` subclass. A mismatch raises a `ValidationError` at construction time, surfacing wrong-YAML-for-wrong-connector mix-ups before any side effects happen.
 - **`connector_config`** (ConnectorSpecificConfig): Your custom configuration model that inherits from `ConnectorSpecificConfig`. The subclass's `CONNECTOR_TYPE` class variable is the source of truth for the connector's identity: it derives the automatic env-var loading prefix `INORBIT_{CONNECTOR_TYPE}_`, drives the metrics namespace and OpenTelemetry resource attribute, and is [automatically published as a key-value](publishing.md#automatic-connector-type-publishing).
 - **`update_freq`** (float): Update frequency in Hz for the execution loop. Default is 1.0
@@ -33,7 +34,8 @@ Connectors parametrize `ConnectorRootConfig[T]` with a concrete `ConnectorSpecif
 `ConnectorRootConfig` is a pydantic-settings `BaseSettings` subclass. Environment variables with the `INORBIT_` prefix are resolved at instantiation time (not import time) and `config/.env` is read automatically. Init kwargs (e.g. from YAML) take precedence over env vars.
 
 - **`INORBIT_API_KEY`**: The InOrbit API key. Required unless `inorbit_robot_key` is provided
-- **`INORBIT_API_URL`** (optional): The InOrbit API endpoint URL
+- **`INORBIT_CONNECTION_CONFIG_URL`** (optional): The connection configuration endpoint URL
+- **`INORBIT_API_URL`** (optional): The InOrbit REST API URL
 
 When `connector_config` is passed as a dict (e.g. from YAML), the `_env_file` override is forwarded to the nested `ConnectorSpecificConfig` constructor. Passing `_env_file=None` to `ConnectorRootConfig` disables dotenv reading for both root and connector-specific fields.
 

--- a/examples/example.env
+++ b/examples/example.env
@@ -2,4 +2,3 @@
 INORBIT_API_KEY=my_super_secret_key
 INORBIT_CONNECTION_CONFIG_URL=https://control.inorbit.ai/cloud_sdk_robot_config
 INORBIT_API_URL=https://api.inorbit.ai
-INORBIT_ACCOUNT_ID=my_super_secret_account_id

--- a/examples/example.env
+++ b/examples/example.env
@@ -1,4 +1,5 @@
 # InOrbit API key - replace with your actual key
 INORBIT_API_KEY=my_super_secret_key
-INORBIT_API_URL=https://control.inorbit.ai/cloud_sdk_robot_config
+INORBIT_CONNECTION_CONFIG_URL=https://control.inorbit.ai/cloud_sdk_robot_config
+INORBIT_API_URL=https://api.inorbit.ai
 INORBIT_ACCOUNT_ID=my_super_secret_account_id

--- a/examples/example.fleet.yaml
+++ b/examples/example.fleet.yaml
@@ -19,8 +19,6 @@ logging:
 connector_type: example_bot
 # Update rate of the connector's main execution loop in Hz
 update_freq: 1.0
-# The ID of the InOrbit account that owns the robots (optional, required for use of footprints)
-account_id: my_inorbit_account
 # Robot key for InOrbit Connect robots (optional, delete if unused)
 # See https://api.inorbit.ai/docs/index.html#operation/generateRobotKey
 inorbit_robot_key:

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -19,8 +19,6 @@ logging:
 connector_type: example_bot
 # Update rate of the connector's main execution loop in Hz
 update_freq: 1.0
-# The ID of the InOrbit account that owns the robots (optional, required for use of footprints)
-account_id: my_inorbit_account
 # Robot key for InOrbit Connect robots (optional, delete if unused)
 # See https://api.inorbit.ai/docs/index.html#operation/generateRobotKey
 inorbit_robot_key:

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -171,7 +171,6 @@ class FleetConnector(ABC):
             api_key=config.api_key,
             endpoint=config.connection_config_url,
             rest_api_endpoint=config.api_url,
-            account_id=config.account_id,
             robot_key=config.inorbit_robot_key,
             robot_id="required_value",
             robot_name="required_value",

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -26,13 +26,11 @@ except ImportError:
 # Third Party
 from inorbit_edge.models import RobotSessionModel
 from inorbit_edge.robot import (
-    INORBIT_REST_API_URL,
     RobotSession,
     RobotSessionPool,
     RobotSessionFactory,
 )
 from inorbit_edge.video import OpenCVCamera
-from pydantic import HttpUrl
 
 # Optional dependency for connector system stats
 try:
@@ -169,17 +167,10 @@ class FleetConnector(ABC):
         # automatically loaded environment variables Robot-specific values (robot_id,
         # robot_name) have to be ommited after initalization before passing the config
         # to the factory.
-        # `rest_api_endpoint` is set explicitly: the SDK's default is a
-        # raw string into a `HttpUrl` field, which trips Pydantic's
-        # serializer warning on every `model_dump()` below. Constructing
-        # a `HttpUrl` here is a no-op for the runtime value but produces
-        # a typed default that serializes cleanly.
         robot_session_config = RobotSessionModel(
             api_key=config.api_key,
-            endpoint=config.api_url,
-            rest_api_endpoint=HttpUrl(
-                os.environ.get("INORBIT_REST_API_URL", INORBIT_REST_API_URL)
-            ),
+            endpoint=config.connection_config_url,
+            rest_api_endpoint=config.api_url,
             account_id=config.account_id,
             robot_key=config.inorbit_robot_key,
             robot_id="required_value",

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -19,7 +19,10 @@ except ImportError:
 # Third-party
 import pytz
 from inorbit_edge.models import CameraConfig
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+from inorbit_edge.robot import (
+    INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL,
+    INORBIT_DEFAULT_API_URL,
+)
 from pydantic import (
     BaseModel,
     DirectoryPath,
@@ -297,8 +300,12 @@ class ConnectorRootConfig(BaseSettings, Generic[T]):
     Attributes:
         api_key (str | None, optional): The InOrbit API key. Required unless
             ``inorbit_robot_key`` is provided.
-        api_url (HttpUrl, optional): The URL of the API or inorbit_edge's
-                                     INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL by default
+        connection_config_url (HttpUrl, optional): The URL of the connection
+            config endpoint or inorbit_edge's INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+            by default. Reads from ``INORBIT_CONNECTION_CONFIG_URL``.
+        api_url (HttpUrl, optional): The URL of the InOrbit REST API or
+            inorbit_edge's INORBIT_DEFAULT_API_URL by default. Reads from
+            ``INORBIT_API_URL``.
         connector_type (str): The type of connector
         connector_config (ConnectorSpecificConfig): Vendor-specific configuration
         use_websockets (bool, optional): If True, the underlying edge-sdk
@@ -336,8 +343,11 @@ class ConnectorRootConfig(BaseSettings, Generic[T]):
     )
 
     api_key: str | None = None
-    api_url: HttpUrl = Field(
+    connection_config_url: HttpUrl = Field(
         default=HttpUrl(INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL),
+    )
+    api_url: HttpUrl = Field(
+        default=HttpUrl(INORBIT_DEFAULT_API_URL),
     )
     connector_type: str
     connector_config: T

--- a/inorbit_connector/models.py
+++ b/inorbit_connector/models.py
@@ -319,8 +319,6 @@ class ConnectorRootConfig(BaseSettings, Generic[T]):
         logging (LoggingConfig, optional): The logging configuration
         user_scripts_dir (DirectoryPath | None, optional): The location of custom user
             scripts
-        account_id (str | None, optional): InOrbit account id, required for publishing
-            footprints
         inorbit_robot_key (str | None, optional): Robot key for InOrbit Connect robots.
             Required unless ``api_key`` is provided.
             See https://api.inorbit.ai/docs/index.html#operation/generateRobotKey
@@ -356,7 +354,6 @@ class ConnectorRootConfig(BaseSettings, Generic[T]):
     location_tz: str = DEFAULT_TIMEZONE
     logging: LoggingConfig = LoggingConfig()
     user_scripts_dir: DirectoryPath | None = None
-    account_id: str | None = None
     inorbit_robot_key: str | None = None
     maps: dict[str, MapConfig] = {}
     env_vars: dict[str, str] = {}
@@ -495,7 +492,7 @@ class ConnectorRootConfig(BaseSettings, Generic[T]):
             raise ValueError("Robot ids must be unique")
         return fleet
 
-    @field_validator("api_key", "account_id")
+    @field_validator("api_key")
     def check_whitespace(cls, value: str | None) -> str | None:
         """Check if the api_key contains whitespace.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "inorbit-edge[telemetry]>=2.1,<3.0",
+    "inorbit-edge[telemetry]>=3.0,<4.0",
     "pydantic>=2.11,<3.0",
     "pydantic-settings>=2.14,<3.0",
     "pytz>=2025.1",
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 video = [
-    "inorbit-edge[video]>=2.1,<3.0",
+    "inorbit-edge[video]>=3.0,<4.0",
 ]
 dev = [
     "bump2version~=1.0",

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -119,7 +119,7 @@ class TestFleetConnectorIsAbstract:
         connector = SubFleetConnector(
             ConnectorRootConfig(
                 api_key="valid_key",
-                api_url="https://valid.com/",
+                connection_config_url="https://valid.com/",
                 connector_type="valid_connector",
                 connector_config=DummyConfig(),
                 fleet=[
@@ -137,7 +137,7 @@ class TestFleetConnector:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connection_config_url": AnyHttpUrl("https://valid.com/"),
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
         }
@@ -402,7 +402,7 @@ class TestFleetConnectorMapFetching:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connection_config_url": AnyHttpUrl("https://valid.com/"),
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
         }
@@ -581,7 +581,7 @@ class TestFleetConnectorDeferredSystemStats:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connection_config_url": AnyHttpUrl("https://valid.com/"),
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
         }
@@ -820,7 +820,7 @@ class TestConnectorIsAbstract:
             "TestRobot",
             ConnectorRootConfig(
                 api_key="valid_key",
-                api_url="https://valid.com/",
+                connection_config_url="https://valid.com/",
                 connector_type="valid_connector",
                 connector_config=DummyConfig(),
                 fleet=[RobotConfig(robot_id="TestRobot")],
@@ -836,7 +836,7 @@ class TestConnector:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connection_config_url": AnyHttpUrl("https://valid.com/"),
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
         }
@@ -1136,7 +1136,7 @@ class TestConnectorCommandHandler:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": AnyHttpUrl("https://valid.com/"),
+            "connection_config_url": AnyHttpUrl("https://valid.com/"),
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,7 @@ class TestConnectorRootConfig:
     def base_model(self):
         return {
             "api_key": "valid_key",
-            "api_url": "https://valid.com/",
+            "connection_config_url": "https://valid.com/",
             "connector_type": "valid_connector",
             "connector_config": DummyConfig(),
             "fleet": [
@@ -68,7 +68,7 @@ class TestConnectorRootConfig:
     def test_with_valid_input(self, base_model):
         model = ConnectorRootConfig(**base_model, _env_file=None)
         assert model.api_key == base_model["api_key"]
-        assert str(model.api_url) == base_model["api_url"]
+        assert str(model.connection_config_url) == base_model["connection_config_url"]
         assert model.connector_type == base_model["connector_type"]
         assert isinstance(model.connector_config, DummyConfig)
         assert len(model.fleet) == 2
@@ -167,8 +167,8 @@ class TestConnectorRootConfig:
         )
         assert model.api_key == "env_valid_key"
 
-    def test_reads_api_url_from_env(self, monkeypatch):
-        monkeypatch.setenv("INORBIT_API_URL", "https://valid.env/")
+    def test_reads_connection_config_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("INORBIT_CONNECTION_CONFIG_URL", "https://valid.env/")
         model = ConnectorRootConfig(
             api_key="valid_key",
             connector_type="valid_connector",
@@ -176,9 +176,9 @@ class TestConnectorRootConfig:
             fleet=[{"robot_id": "robot1"}],
             _env_file=None,
         )
-        assert str(model.api_url) == "https://valid.env/"
+        assert str(model.connection_config_url) == "https://valid.env/"
 
-    def test_api_url_default_when_no_env(self):
+    def test_connection_config_url_default_when_no_env(self):
         model = ConnectorRootConfig(
             api_key="valid_key",
             connector_type="valid_connector",
@@ -186,7 +186,18 @@ class TestConnectorRootConfig:
             fleet=[{"robot_id": "robot1"}],
             _env_file=None,
         )
-        assert str(model.api_url) == INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+        assert str(model.connection_config_url) == INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+
+    def test_reads_api_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("INORBIT_API_URL", "https://custom-api.env/")
+        model = ConnectorRootConfig(
+            api_key="valid_key",
+            connector_type="valid_connector",
+            connector_config=DummyConfig(),
+            fleet=[{"robot_id": "robot1"}],
+            _env_file=None,
+        )
+        assert str(model.api_url) == "https://custom-api.env/"
 
     def test_api_key_none_with_robot_key(self):
         """api_key can be None when inorbit_robot_key provides authentication."""


### PR DESCRIPTION
## Summary

Aligns connector-python with edge-sdk v3 env var consolidation from inorbit-ai/edge-sdk-python#96

The config endpoint and REST API now have unambiguous, non-colliding env var names across the Connect SDK stack.

- Rename `api_url` field → `connection_config_url` (reads `INORBIT_CONNECTION_CONFIG_URL`)
- Add new `api_url` field for the REST API (reads `INORBIT_API_URL`, defaults to `https://api.inorbit.ai`)
- Remove manual `os.environ.get("INORBIT_REST_API_URL", …)` from connector — REST API URL now flows through config like every other setting
- Bump `inorbit-edge` dependency to `>=3.0,<4.0`
- Update env files, docs, and tests

### Before

| Env Var | Field | Actual endpoint |
|---|---|---|
| `INORBIT_API_URL` | `api_url` | Config |
| `INORBIT_REST_API_URL` | *(manual `os.environ.get`)* | REST API |

### After

| Env Var | Field | Actual endpoint | Default |
|---|---|---|---|
| `INORBIT_CONNECTION_CONFIG_URL` | `connection_config_url` | Config | `https://control.inorbit.ai/cloud_sdk_robot_config` |
| `INORBIT_API_URL` | `api_url` | REST API | `https://api.inorbit.ai` |

### Breaking changes

- `INORBIT_API_URL` no longer sets the config endpoint — use `INORBIT_CONNECTION_CONFIG_URL`
- Python field `ConnectorRootConfig.api_url` renamed to `connection_config_url`
- Requires `inorbit-edge>=3.0`