### PR TITLE
Bump version: 3.1.0 → 3.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = true
-current_version = 3.1.0
+current_version = 3.2.0
 tag = true
 
 [bumpversion:file:setup.py]

--- a/inorbit_connector/__init__.py
+++ b/inorbit_connector/__init__.py
@@ -6,4 +6,4 @@
 # SPDX-License-Identifier: MIT
 
 __author__ = "InOrbit, Inc."
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 GITHUB_ORG_URL = "https://github.com/inorbit-ai"
 GITHUB_REPO_URL = f"{GITHUB_ORG_URL}/inorbit-connector-python"
-VERSION = "3.1.0"
+VERSION = "3.2.0"
 
 setup(
     download_url=f"{GITHUB_REPO_URL}/archive/refs/tags/v{VERSION}.zip",


### PR DESCRIPTION
Minor version bump 3.1.0 → 3.2.0. Releases #83 (supervised background-task helpers `_create_supervised_task` / `_spawn_logged_task`, and `inorbit-edge>=3.1.0`).