### PR TITLE
Add install_signal_handlers() covering SIGTERM, not just SIGINT

### DIFF
--- a/examples/fleet-connector/main.py
+++ b/examples/fleet-connector/main.py
@@ -4,7 +4,6 @@
 
 import argparse
 import logging
-import signal
 import sys
 
 from inorbit_connector.utils import read_yaml
@@ -70,9 +69,8 @@ def start():
     LOGGER.info("Starting fleet connector...")
     connector.start()
 
-    # Register a signal handler for graceful shutdown
-    # When a keyboard interrupt is received (Ctrl+C), the connector will be stopped
-    signal.signal(signal.SIGINT, lambda sig, frame: connector.stop())
+    # Stop cleanly on Ctrl+C and on the SIGTERM a container runtime sends
+    connector.install_signal_handlers()
 
     # Wait for the connector to finish
     connector.join()

--- a/examples/robot-connector/main.py
+++ b/examples/robot-connector/main.py
@@ -4,7 +4,6 @@
 
 import argparse
 import logging
-import signal
 import sys
 
 from inorbit_connector.utils import read_yaml
@@ -64,9 +63,8 @@ def start():
     LOGGER.info("Starting connector...")
     connector.start()
 
-    # Register a signal handler for graceful shutdown
-    # When a keyboard interrupt is received (Ctrl+C), the connector will be stopped
-    signal.signal(signal.SIGINT, lambda sig, frame: connector.stop())
+    # Stop cleanly on Ctrl+C and on the SIGTERM a container runtime sends
+    connector.install_signal_handlers()
 
     # Wait for the connector to finish
     connector.join()

--- a/examples/simple-connector/connector.py
+++ b/examples/simple-connector/connector.py
@@ -9,7 +9,6 @@
 import asyncio
 import logging
 import random
-import signal
 from pathlib import Path
 
 try:
@@ -222,9 +221,8 @@ def main():
     connector = ExampleBotConnector(ROBOT_ID, config)
     connector.start()
 
-    # Register a signal handler for graceful shutdown
-    # When a keyboard interrupt is received (Ctrl+C), the connector will be stopped
-    signal.signal(signal.SIGINT, lambda sig, frame: connector.stop())
+    # Stop cleanly on Ctrl+C and on the SIGTERM a container runtime sends
+    connector.install_signal_handlers()
 
     # Wait for the connector to finish
     connector.join()

--- a/examples/simple-fleet-connector/connector.py
+++ b/examples/simple-fleet-connector/connector.py
@@ -9,7 +9,6 @@
 import asyncio
 import logging
 import random
-import signal
 from pathlib import Path
 
 try:
@@ -240,9 +239,8 @@ def main():
     connector = ExampleBotFleetConnector(config)
     connector.start()
 
-    # Register a signal handler for graceful shutdown
-    # When a keyboard interrupt is received (Ctrl+C), the connector will be stopped
-    signal.signal(signal.SIGINT, lambda sig, frame: connector.stop())
+    # Stop cleanly on Ctrl+C and on the SIGTERM a container runtime sends
+    connector.install_signal_handlers()
 
     # Wait for the connector to finish
     connector.join()

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -8,6 +8,7 @@
 # Standard
 import os
 import logging
+import signal
 import socket
 from pathlib import Path
 import tempfile
@@ -777,6 +778,36 @@ class FleetConnector(ABC):
         will block until it ends.
         """
         self.__thread.join()
+
+    def install_signal_handlers(self, signums=(signal.SIGINT, signal.SIGTERM)) -> None:
+        """Stop this connector when the process is asked to terminate.
+
+        Handles SIGTERM as well as SIGINT: SIGTERM is what `docker stop`,
+        `compose restart` and Kubernetes send, and a containerized connector is
+        usually PID 1, where the kernel applies no default action -- an
+        unhandled SIGTERM is ignored outright and the runtime SIGKILLs after its
+        grace period. That skips stop() entirely, so external services are never
+        disconnected, cameras are never released and InOrbit keeps a stale
+        session until it times out.
+
+        Must be called from the main thread (a Python limitation on installing
+        signal handlers). Call it after start() and before join().
+
+        Args:
+            signums: Signals to handle. Defaults to SIGINT and SIGTERM.
+        """
+
+        def _stop(signum, _frame) -> None:
+            self._logger.info(f"Received {signal.Signals(signum).name}; stopping")
+            try:
+                self.stop()
+            except Exception:
+                # Never raise out of a signal handler: the connector thread is
+                # not a daemon, so its teardown still runs as the process exits.
+                self._logger.exception("Connector did not stop cleanly")
+
+        for signum in signums:
+            signal.signal(signum, _stop)
 
     def stop(self) -> None:
         """Stop the execution loop of this connector.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -9,6 +9,7 @@
 import asyncio
 import logging
 import os
+import signal
 import threading
 from contextlib import contextmanager
 from time import sleep
@@ -1916,3 +1917,41 @@ class TestSupervisedBackgroundTasks:
         msgs = [r.getMessage() for r in caplog.records]
         assert any("kaboom" in m for m in msgs)  # the exception is surfaced
         assert any("oneshot" in m for m in msgs)  # ...tagged with the task name
+
+
+class TestSignalHandlers:
+    """install_signal_handlers() must cover SIGTERM, not just SIGINT.
+
+    A containerized connector is usually PID 1, where an unhandled SIGTERM is
+    ignored and the runtime SIGKILLs it -- skipping stop() and its cleanup.
+    """
+
+    @contextmanager
+    def _restored_handlers(self):
+        signums = (signal.SIGINT, signal.SIGTERM)
+        previous = {signum: signal.getsignal(signum) for signum in signums}
+        try:
+            yield
+        finally:
+            for signum, handler in previous.items():
+                signal.signal(signum, handler)
+
+    def test_sigint_and_sigterm_both_stop_the_connector(self):
+        connector = MagicMock()
+        with self._restored_handlers():
+            FleetConnector.install_signal_handlers(connector)
+
+            for signum in (signal.SIGINT, signal.SIGTERM):
+                signal.getsignal(signum)(signum, None)
+
+        assert connector.stop.call_count == 2
+
+    def test_a_failing_stop_does_not_raise_out_of_the_handler(self):
+        connector = MagicMock()
+        connector.stop.side_effect = Exception("did not stop in time")
+        with self._restored_handlers():
+            FleetConnector.install_signal_handlers(connector)
+
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+
+        connector._logger.exception.assert_called_once()


### PR DESCRIPTION
Every connector hand-rolls `signal.signal(signal.SIGINT, ...)` — the four examples here, mir, gausium, omron, safeguard — and none of them handle **SIGTERM**, which is what `docker stop`, `compose restart` and Kubernetes send.

A containerized connector is usually PID 1, where the kernel applies no default action, so an unhandled SIGTERM is *ignored* and the runtime SIGKILLs after its grace period. Verified in a container: `docker stop -t 5` takes the full 5s and exits 137; with a handler, 0s and exit 0. On SIGKILL `stop()` never runs — external services aren't disconnected, cameras aren't released (no RTSP TEARDOWN, so a camera that caps concurrent sessions can refuse the restarted connector) and InOrbit keeps a stale session until it times out.

`Connector.install_signal_handlers()` handles both signals, logs which arrived, and swallows a failing `stop()` instead of raising out of a signal handler. Examples updated to use it.

Tests: 2 new cases. Suite green (233), flake8/black clean.