### PR TITLE
Let stop() wait out the teardown it triggers

### DIFF
--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -72,6 +72,13 @@ class FleetConnector(ABC):
     See self.__init__() for more details.
     """
 
+    #: How long stop() waits for the connector thread before giving up. It has to
+    #: cover the whole teardown: RobotSession.disconnect() alone allows up to 12s
+    #: for camera streamers (a worker can be mid-open on an unreachable stream)
+    #: before the MQTT disconnect, so a shorter wait made an ordinary shutdown
+    #: with cameras registered raise "Thread did not stop in time".
+    STOP_TIMEOUT_SECONDS = 30.0
+
     def __init__(self, config: ConnectorRootConfig, **kwargs) -> None:
         """Initialize the base connector with common functionality.
 
@@ -809,18 +816,27 @@ class FleetConnector(ABC):
         for signum in signums:
             signal.signal(signum, _stop)
 
-    def stop(self) -> None:
+    def stop(self, timeout: float | None = None) -> None:
         """Stop the execution loop of this connector.
 
         This method should be called to stop the execution loop of this connector, will
         block until the execution loop is stopped, and will call disconnect() to clean
         up any external connections.
+
+        Args:
+            timeout (float | None): Seconds to wait for the connector thread.
+                Defaults to STOP_TIMEOUT_SECONDS.
+
+        Raises:
+            Exception: If the connector thread is still running after ``timeout``.
         """
 
         # Stop the execution loop
         self._logger.info("Stopping connector")
         self.__stop_event.set()
-        self.__thread.join(timeout=5)
+        self.__thread.join(
+            timeout=self.STOP_TIMEOUT_SECONDS if timeout is None else timeout
+        )
         if self._metrics_server is not None:
             self._metrics_server.stop()
         if self.__thread.is_alive():

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -75,7 +75,7 @@ class FleetConnector(ABC):
     # How long stop() waits for the connector thread before giving up. It has to
     # cover the whole teardown: RobotSession.disconnect() alone allows up to 12s
     # for camera streamers (a worker can be mid-open on an unreachable stream)
-    # before the MQTT disconnect. A shorter wait with cameras registered may 
+    # before the MQTT disconnect. A shorter wait with cameras registered may
     # raise "Thread did not stop in time".
     STOP_TIMEOUT_SECONDS = 30.0
 

--- a/inorbit_connector/connector.py
+++ b/inorbit_connector/connector.py
@@ -72,11 +72,11 @@ class FleetConnector(ABC):
     See self.__init__() for more details.
     """
 
-    #: How long stop() waits for the connector thread before giving up. It has to
-    #: cover the whole teardown: RobotSession.disconnect() alone allows up to 12s
-    #: for camera streamers (a worker can be mid-open on an unreachable stream)
-    #: before the MQTT disconnect, so a shorter wait made an ordinary shutdown
-    #: with cameras registered raise "Thread did not stop in time".
+    # How long stop() waits for the connector thread before giving up. It has to
+    # cover the whole teardown: RobotSession.disconnect() alone allows up to 12s
+    # for camera streamers (a worker can be mid-open on an unreachable stream)
+    # before the MQTT disconnect. A shorter wait with cameras registered may 
+    # raise "Thread did not stop in time".
     STOP_TIMEOUT_SECONDS = 30.0
 
     def __init__(self, config: ConnectorRootConfig, **kwargs) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1955,3 +1955,18 @@ class TestSignalHandlers:
             signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
 
         connector._logger.exception.assert_called_once()
+
+
+class TestStopTimeout:
+    def test_stop_waits_long_enough_for_camera_teardown(self):
+        """RobotSession.disconnect() alone allows 12s for camera streamers."""
+        assert FleetConnector.STOP_TIMEOUT_SECONDS > 12
+
+    def test_stop_timeout_is_overridable(self):
+        connector = MagicMock()
+        connector._FleetConnector__thread = MagicMock(is_alive=lambda: False)
+        connector._metrics_server = None
+
+        FleetConnector.stop(connector, timeout=0.25)
+
+        connector._FleetConnector__thread.join.assert_called_once_with(timeout=0.25)


### PR DESCRIPTION
Stacked on #86.

`stop()` joined the connector thread for 5s then raised `Thread did not stop in time`, but the teardown it triggers can legitimately take longer: `RobotSession.disconnect()` alone allows up to 12s for camera streamers (a worker can be mid-open on an unreachable stream) before the MQTT disconnect. So an ordinary shutdown with cameras registered raised even though nothing was wrong — which also masks real hangs, since the exception means nothing.

Wait is now `STOP_TIMEOUT_SECONDS` (30s), overridable per call via a new `timeout` argument.

Tests: 2 new cases. Suite green (235), flake8/black clean.