### PR TITLE
Pin the release tag to the commit that published

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -116,13 +116,18 @@ jobs:
             RELEASE_TAG="v$VERSION"
           fi
 
-          # Create or update the release
+          # Create the release, or leave an existing one alone. --target pins the
+          # tag to the commit that published: without it `gh release create` tags
+          # whatever the default branch points at when the job runs, which is a
+          # different commit if anything landed while the build was running.
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Updating existing release $RELEASE_TAG"
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --notes ""
+            echo "Release $RELEASE_TAG already exists; leaving its notes untouched"
           else
             echo "Creating new release $RELEASE_TAG"
-            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --notes ""
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --generate-notes
           fi
 
           # Save the release tag for the next step

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,4 +170,24 @@ CI automatically publishes to PyPI when either:
 - A tag is pushed, or
 - A commit message contains "Bump version"
 
-After publishing to PyPI, CI also signs the artifacts and creates/updates the GitHub Release.
+After publishing to PyPI, CI also signs the artifacts and creates the GitHub Release,
+tagging the commit that published.
+
+### Bumping through a pull request
+
+If the bump has to go through review instead of straight to `main`, pass `--no-tag`
+and let CI create the tag:
+
+```bash
+git checkout -b bump-version-x.y.z
+bump2version --no-tag minor
+git push -u origin bump-version-x.y.z
+```
+
+**Keep `Bump version: X.Y.Z → A.B.C` as the pull request title.** The publish job
+matches on the commit message and a squash merge takes the title, so a reworded
+title silently skips the release.
+
+`--no-tag` matters because a bump merged from a branch is squashed or rebased into
+a different commit, so a tag `bump2version` created locally would point at something
+that never reaches `main` — that is how `v3.0.0` ended up unreachable from `main`.


### PR DESCRIPTION
Worth saying up front: **this repo does not have the problem edge-sdk-python had.** Its publish workflow already derives the version from the bump commit and calls `gh release create`, which creates the tag too, so `v3.2.0`, `v3.1.0` and `v2.5.0` are all reachable from `main`. Only `v3.0.0` dangles, and it predates that workflow.

Two smaller gaps remain:

- **`gh release create` ran without `--target`**, so it tags whatever the default branch points at *when the job runs*. If anything lands on `main` while the build is running, the tag ends up on a different commit than the one that published. Now pinned to `$GITHUB_SHA`.
- **A job re-run wiped the release notes** — the existing-release path called `gh release edit --notes ""`. It now leaves an existing release untouched, and new releases get `--generate-notes` instead of empty notes.

`CONTRIBUTING.md` gains the bump-through-a-PR variant next to the existing bump-on-`main` instructions: `--no-tag`, and the bit that silently breaks a release otherwise — the publish job matches on the commit message, and a squash merge takes the PR title, so the title has to stay `Bump version: X.Y.Z → A.B.C`.