### PR TITLE
Bump version: 3.2.0 → 3.2.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = true
-current_version = 3.2.0
+current_version = 3.2.1
 tag = true
 
 [bumpversion:file:setup.py]

--- a/inorbit_connector/__init__.py
+++ b/inorbit_connector/__init__.py
@@ -6,4 +6,4 @@
 # SPDX-License-Identifier: MIT
 
 __author__ = "InOrbit, Inc."
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 GITHUB_ORG_URL = "https://github.com/inorbit-ai"
 GITHUB_REPO_URL = f"{GITHUB_ORG_URL}/inorbit-connector-python"
-VERSION = "3.2.0"
+VERSION = "3.2.1"
 
 setup(
     download_url=f"{GITHUB_REPO_URL}/archive/refs/tags/v{VERSION}.zip",


### PR DESCRIPTION
`bump2version --no-tag patch`. Releases what landed since 3.2.0:

- **#86** — `Connector.install_signal_handlers()`, handling SIGTERM as well as SIGINT. A containerized connector is usually PID 1, where an unhandled SIGTERM is ignored and the runtime SIGKILLs after its grace period, so `stop()` never runs: external services stay connected, cameras are never released and InOrbit keeps a stale session. The four examples now use it.
- **#87** — `stop()` waits `STOP_TIMEOUT_SECONDS` (30s) instead of 5s, and takes an optional `timeout`. `RobotSession.disconnect()` alone allows up to 12s for camera streamers, so an ordinary shutdown with cameras registered used to raise `Thread did not stop in time`.

Both are additive, so a minor would also be defensible — patch per request.

Title must stay as-is: the publish job matches on the commit message, and a squash merge takes the PR title.

`--no-tag` because the bump arrives through a PR; the publish workflow creates the tag and GitHub Release itself. #89 (pending) pins that tag to the publishing commit, but nothing here depends on it landing first.